### PR TITLE
Empty civilian vehicles

### DIFF
--- a/addons/civilian/XEH_PREP.hpp
+++ b/addons/civilian/XEH_PREP.hpp
@@ -7,3 +7,4 @@ PREP(initCity);
 PREP(initCityCivilians);
 //PREP(initCityVehicles);
 PREP(initCivilian);
+PREP(setVehicleRandomTexture);

--- a/addons/civilian/XEH_PREP.hpp
+++ b/addons/civilian/XEH_PREP.hpp
@@ -10,4 +10,6 @@ PREP(initCity);
 PREP(initCityCivilians);
 PREP(initVehicles);
 PREP(initCivilian);
+PREP(isHouseNearby);
+PREP(isRoadNearby);
 PREP(setVehicleRandomTexture);

--- a/addons/civilian/XEH_PREP.hpp
+++ b/addons/civilian/XEH_PREP.hpp
@@ -1,11 +1,12 @@
 PREP(assignCityCivilian);
 PREP(createCivilian);
+PREP(createVehicle);
 PREP(getCityByLocation);
 PREP(getCityName);
 PREP(getCityRandomPos);
 PREP(getNearestCity);
 PREP(initCity);
 PREP(initCityCivilians);
-//PREP(initCityVehicles);
+PREP(initVehicles);
 PREP(initCivilian);
 PREP(setVehicleRandomTexture);

--- a/addons/civilian/XEH_PREP.hpp
+++ b/addons/civilian/XEH_PREP.hpp
@@ -2,6 +2,7 @@ PREP(assignCityCivilian);
 PREP(createCivilian);
 PREP(getCityByLocation);
 PREP(getCityName);
+PREP(getCityRandomPos);
 PREP(getNearestCity);
 PREP(initCity);
 PREP(initCityCivilians);

--- a/addons/civilian/XEH_PREP.hpp
+++ b/addons/civilian/XEH_PREP.hpp
@@ -5,6 +5,7 @@ PREP(getCityByLocation);
 PREP(getCityName);
 PREP(getCityRandomPos);
 PREP(getNearestCity);
+PREP(getRandomPos);
 PREP(initCity);
 PREP(initCityCivilians);
 PREP(initVehicles);

--- a/addons/civilian/XEH_preInit.sqf
+++ b/addons/civilian/XEH_preInit.sqf
@@ -14,6 +14,12 @@ if (isServer) then {
     // Maximum civilians count (TODO: as setting with randomization options)
     GVAR(civiliansCount) = 100 + floor (random (101));
 
+    // Weights for vehicles and civilians creation
+    GVAR(weightCapital) = ceil (random (10));
+    GVAR(weightCity) = ceil (random (8));
+    GVAR(weightVillage) = ceil (random (6));
+    GVAR(weightRural) = ceil (random (10));
+
     // Initialize all cities found on the map
     {
         GVAR(cities) pushBack ([_x] call FUNC(initCity));
@@ -21,11 +27,6 @@ if (isServer) then {
 
     publicVariable QGVAR(cities);
 
-    // Weights for vehicles and civilians creation
-    GVAR(weightCapital) = ceil (random (10));
-    GVAR(weightCity) = ceil (random (8));
-    GVAR(weightVillage) = ceil (random (6));
-    GVAR(weightRural) = ceil (random (10));
 
     // We need some improvements in determining civilian vehicles limit
     GVAR(emptyVehiclesLimit) = GVAR(emptyVehiclesLimitMultiplier) * 200;

--- a/addons/civilian/XEH_preInit.sqf
+++ b/addons/civilian/XEH_preInit.sqf
@@ -21,6 +21,12 @@ if (isServer) then {
 
     publicVariable QGVAR(cities);
 
+    // Weights for vehicles and civilians creation
+    GVAR(weightCapital) = ceil (random (10));
+    GVAR(weightCity) = ceil (random (8));
+    GVAR(weightVillage) = ceil (random (6));
+    GVAR(weightRural) = ceil (random (10));
+
     GVAR(emptyVehiclesLimit) = GVAR(emptyVehiclesLimitMultiplier) * 200;
     call FUNC(initVehicles);
 };

--- a/addons/civilian/XEH_preInit.sqf
+++ b/addons/civilian/XEH_preInit.sqf
@@ -29,7 +29,7 @@ if (isServer) then {
 
 
     // We need some improvements in determining civilian vehicles limit
-    GVAR(emptyVehiclesLimit) = GVAR(emptyVehiclesLimitMultiplier) * 200;
+    GVAR(emptyVehiclesLimit) = GVAR(emptyVehiclesLimitMultiplier) * (3 * count (GVAR(cities)));
     call FUNC(initVehicles);
 };
 

--- a/addons/civilian/XEH_preInit.sqf
+++ b/addons/civilian/XEH_preInit.sqf
@@ -27,6 +27,7 @@ if (isServer) then {
     GVAR(weightVillage) = ceil (random (6));
     GVAR(weightRural) = ceil (random (10));
 
+    // We need some improvements in determining civilian vehicles limit
     GVAR(emptyVehiclesLimit) = GVAR(emptyVehiclesLimitMultiplier) * 200;
     call FUNC(initVehicles);
 };

--- a/addons/civilian/XEH_preInit.sqf
+++ b/addons/civilian/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 ADDON = false;
 #include "XEH_PREP.hpp"
 
+#include "initSettings.sqf"
+
 if (isServer) then {
     // Create namespace for linking location classname with city
     GVAR(citiesLocations) = true call CBA_fnc_createNamespace;
@@ -19,8 +21,7 @@ if (isServer) then {
 
     publicVariable QGVAR(cities);
 
-    GVAR(emptyVehiclesLimit) = 200;
-
+    GVAR(emptyVehiclesLimit) = GVAR(emptyVehiclesLimitMultiplier) * 200;
     call FUNC(initVehicles);
 };
 

--- a/addons/civilian/XEH_preInit.sqf
+++ b/addons/civilian/XEH_preInit.sqf
@@ -29,7 +29,7 @@ if (isServer) then {
 
 
     // We need some improvements in determining civilian vehicles limit
-    GVAR(emptyVehiclesLimit) = GVAR(emptyVehiclesLimitMultiplier) * (3 * count (GVAR(cities)));
+    GVAR(emptyVehiclesLimit) = GVAR(emptyVehiclesLimitMultiplier) * (5 * count (GVAR(cities)));
     call FUNC(initVehicles);
 };
 

--- a/addons/civilian/XEH_preInit.sqf
+++ b/addons/civilian/XEH_preInit.sqf
@@ -18,6 +18,10 @@ if (isServer) then {
     } forEach EGVAR(common,cities);
 
     publicVariable QGVAR(cities);
+
+    GVAR(emptyVehiclesLimit) = 200;
+
+    call FUNC(initVehicles);
 };
 
 ADDON = true;

--- a/addons/civilian/functions/fnc_createCivilian.sqf
+++ b/addons/civilian/functions/fnc_createCivilian.sqf
@@ -18,7 +18,6 @@
 params ["_cityNamespace"];
 
 private _newGroup = createGroup CIVILIAN;
-private _cityPosition = _cityNamespace getVariable [QGVAR(Position), [0, 0, 0]];
-private _position = [[[_cityPosition, 100]]] call BIS_fnc_randomPos;
+private _position = [_cityNamespace] call FUNC(getCityRandomPos);
 
 _newGroup createUnit ["C_man_polo_1_F", _position, [], 0, "NONE"];

--- a/addons/civilian/functions/fnc_createVehicle.sqf
+++ b/addons/civilian/functions/fnc_createVehicle.sqf
@@ -17,13 +17,14 @@
  * Public: No
  */
 
-params ["_vehicleClassname", "_position", ["_emptyCargo", true]];
+params ["_vehicleClassname", "_position", ["_dir", random 360], ["_emptyCargo", true]];
 
 if (_vehicleClassname isEqualType configNull) then {
     _vehicleClassname = configName _vehicleClassname;
 };
 
 private _vehicle = createVehicle [_vehicleClassname, _position, [], 0, "NONE"];
+_vehicle setDir _dir;
 _vehicle setVariable ["BIS_enableRandomization", false];
 [_vehicle] call FUNC(setVehicleRandomTexture);
 

--- a/addons/civilian/functions/fnc_createVehicle.sqf
+++ b/addons/civilian/functions/fnc_createVehicle.sqf
@@ -25,6 +25,7 @@ if (_vehicleClassname isEqualType configNull) then {
 
 private _vehicle = createVehicle [_vehicleClassname, _position, [], 0, "NONE"];
 _vehicle setDir _dir;
+// Disable randomization and use own function to set texture on vehicle globally (so everyone can see the same color!)
 _vehicle setVariable ["BIS_enableRandomization", false];
 [_vehicle] call FUNC(setVehicleRandomTexture);
 
@@ -34,6 +35,7 @@ if (_emptyCargo) then {
     clearWeaponCargoGlobal _vehicle;
 };
 
+// For ACE support so players can repair their wheels/tracks if crashed
 if (EGVAR(common,ACE_Loaded)) then {
     if (_vehicle isKindOf "Tank") then {
         ["ACE_Track", _veh] call ace_cargo_fnc_loadItem;

--- a/addons/civilian/functions/fnc_createVehicle.sqf
+++ b/addons/civilian/functions/fnc_createVehicle.sqf
@@ -4,7 +4,7 @@
  * Function creates vehicle on given position.
  *
  * Arguments:
- * 0: Vehicle classname <STRING>
+ * 0: Vehicle classname or config <STRING/CONFIG>
  * 1: Position <POSITION>
  * 2: Remove cargo <BOOL>
  *
@@ -18,6 +18,10 @@
  */
 
 params ["_vehicleClassname", "_position", ["_emptyCargo", true]];
+
+if (_vehicleClassname isEqualType configNull) then {
+    _vehicleClassname = configName _vehicleClassname;
+};
 
 private _vehicle = createVehicle [_vehicleClassname, _position, [], 0, "NONE"];
 _vehicle setVariable ["BIS_enableRandomization", false];

--- a/addons/civilian/functions/fnc_createVehicle.sqf
+++ b/addons/civilian/functions/fnc_createVehicle.sqf
@@ -37,6 +37,7 @@ if (_emptyCargo) then {
 
 // For ACE support so players can repair their wheels/tracks if crashed
 if (EGVAR(common,ACE_Loaded)) then {
+    if (_vehicle isKindOf "Air" || {_vehicle isKindOf "Ship"}) exitWith {};
     if (_vehicle isKindOf "Tank") then {
         ["ACE_Track", _veh] call ace_cargo_fnc_loadItem;
     } else {

--- a/addons/civilian/functions/fnc_createVehicle.sqf
+++ b/addons/civilian/functions/fnc_createVehicle.sqf
@@ -1,0 +1,42 @@
+#include "script_component.hpp"
+/*
+ * Author: 3Mydlo3
+ * Function creates vehicle on given position.
+ *
+ * Arguments:
+ * 0: Vehicle classname <STRING>
+ * 1: Position <POSITION>
+ * 2: Remove cargo <BOOL>
+ *
+ * Return Value:
+ * 0: Created vehicle <OBJECT>
+ *
+ * Example:
+ * ["C_Offroad_01_F", position player] call afsk_civilian_fnc_createVehicle
+ *
+ * Public: No
+ */
+
+params ["_vehicleClassname", "_position", ["_emptyCargo", true]];
+
+private _vehicle = createVehicle [_vehicleClassname, _position, [], 0, "NONE"];
+_vehicle setVariable ["BIS_enableRandomization", false];
+[_vehicle] call FUNC(setVehicleRandomTexture);
+
+if (_emptyCargo) then {
+    clearItemCargoGlobal _vehicle;
+    clearMagazineCargoGlobal _vehicle;
+    clearWeaponCargoGlobal _vehicle;
+};
+
+if (EGVAR(common,ACE_Loaded)) then {
+    if (_vehicle isKindOf "Tank") then {
+        ["ACE_Track", _veh] call ace_cargo_fnc_loadItem;
+    } else {
+        ["ACE_Wheel", _veh] call ace_cargo_fnc_loadItem;
+        ["ACE_Wheel", _veh] call ace_cargo_fnc_loadItem;
+        ["ACE_Wheel", _veh] call ace_cargo_fnc_loadItem;
+    };
+};
+
+_vehicle

--- a/addons/civilian/functions/fnc_getCityRandomPos.sqf
+++ b/addons/civilian/functions/fnc_getCityRandomPos.sqf
@@ -29,7 +29,7 @@ private _fnc_randomPos = {
         private _roads = _cityPosition nearRoads ((_cityAreaSize select 0) max (_cityAreaSize select 1));
         private _randomRoadPos = getPos (selectRandom _roads);
         if (_emptyPosSearchRadius isEqualTo 0) exitWith {_randomRoadPos};
-        [[[_cityPosition, _emptyPosSearchRadius]]] call BIS_fnc_randomPos;
+        [[[_randomRoadPos, _emptyPosSearchRadius]]] call BIS_fnc_randomPos;
     } else {
         [[[_cityPosition, [_cityAreaSize select 0, _cityAreaSize select 1, 0, true]]]] call BIS_fnc_randomPos;
     };

--- a/addons/civilian/functions/fnc_getCityRandomPos.sqf
+++ b/addons/civilian/functions/fnc_getCityRandomPos.sqf
@@ -22,6 +22,7 @@ private _cityPosition = _cityNamespace getVariable QGVAR(Position);
 private _cityArea = _cityNamespace getVariable QGVAR(cityArea);
 private _cityAreaSize = [_cityArea select 1 select 0, _cityArea select 1 select 1];
 
+// Function returns position random position in area
 private _fnc_randomPos = {
     params ["_cityPosition", "_cityAreaSize", "_nearRoad"];
     if (_nearRoad) then {
@@ -34,12 +35,13 @@ private _fnc_randomPos = {
     };
 };
 
+// If no object is given, just random position is enough
 if (_object isEqualTo objNull) exitWith {[_cityPosition, _cityAreaSize, _nearRoad] call _fnc_randomPos};
 
 private _location = _cityNamespace getVariable QGVAR(Location);
-
-private _randomPos = [0, 0, 0];
+private _randomPos = [];
 private _loopLimit = 100;
+// Loop until acquired random empty pos is within location area (or loop limit reached)
 while {(_loopLimit >= 0) && {!(_randomPos isEqualTo []) && {!(_randomPos inArea _location)}}} do {
     _randomPos = [_cityPosition, _cityAreaSize, _nearRoad] call _fnc_randomPos;
     _randomPos = _randomPos findEmptyPosition [0, _emptyPosSearchRadius, _object];

--- a/addons/civilian/functions/fnc_getCityRandomPos.sqf
+++ b/addons/civilian/functions/fnc_getCityRandomPos.sqf
@@ -5,7 +5,7 @@
  *
  * Arguments:
  * 0: City namespace <CBA_NAMESPACE>
- * 1: Object to fit in <OBJECT>
+ * 1: Object (classname/config) to fit in <OBJECT/STRING/CONFIG>
  *
  * Return Value:
  * 0: Random position inside city <POSITION>
@@ -16,7 +16,7 @@
  * Public: No
  */
 
-params ["_cityNamespace", ["_object", objNull], ["_nearRoad", false], ["_emptyPosSearchRadius", 25]];
+params ["_cityNamespace", ["_objectType", ""], ["_nearRoad", false], ["_emptyPosSearchRadius", 25]];
 
 private _cityPosition = _cityNamespace getVariable QGVAR(Position);
 private _cityArea = _cityNamespace getVariable QGVAR(cityArea);
@@ -35,8 +35,17 @@ private _fnc_randomPos = {
     };
 };
 
+if (!(_objectType isEqualType "")) then {
+    if (_objectType isEqualType configNull) then {
+        _objectType = configName _objectType;
+    };
+    if (_objectType isEqualType objNull) then {
+        _objectType = typeOf _objectType;
+    };
+};
+
 // If no object is given, just random position is enough
-if (_object isEqualTo objNull) exitWith {[_cityPosition, _cityAreaSize, _nearRoad] call _fnc_randomPos};
+if (_objectType isEqualTo "") exitWith {[_cityPosition, _cityAreaSize, _nearRoad] call _fnc_randomPos};
 
 private _location = _cityNamespace getVariable QGVAR(Location);
 private _randomPos = [];
@@ -44,7 +53,7 @@ private _loopLimit = 100;
 // Loop until acquired random empty pos is within location area (or loop limit reached)
 while {(_loopLimit >= 0) && {!(_randomPos isEqualTo []) && {!(_randomPos inArea _location)}}} do {
     _randomPos = [_cityPosition, _cityAreaSize, _nearRoad] call _fnc_randomPos;
-    _randomPos = _randomPos findEmptyPosition [0, _emptyPosSearchRadius, _object];
+    _randomPos = _randomPos findEmptyPosition [0, _emptyPosSearchRadius, _objectType];
     _loopLimit = _loopLimit - 1;
 };
 

--- a/addons/civilian/functions/fnc_getCityRandomPos.sqf
+++ b/addons/civilian/functions/fnc_getCityRandomPos.sqf
@@ -51,7 +51,7 @@ private _location = _cityNamespace getVariable QGVAR(Location);
 private _randomPos = [];
 private _loopLimit = 100;
 // Loop until acquired random empty pos is within location area (or loop limit reached)
-while {(_loopLimit >= 0) && {!(_randomPos isEqualTo []) && {!(_randomPos inArea _location)}}} do {
+while {(_loopLimit >= 0) && {(_randomPos isEqualTo []) || {!(_randomPos inArea _location)}}} do {
     _randomPos = [_cityPosition, _cityAreaSize, _nearRoad] call _fnc_randomPos;
     _randomPos = _randomPos findEmptyPosition [0, _emptyPosSearchRadius, _objectType];
     _loopLimit = _loopLimit - 1;

--- a/addons/civilian/functions/fnc_getCityRandomPos.sqf
+++ b/addons/civilian/functions/fnc_getCityRandomPos.sqf
@@ -29,7 +29,7 @@ private _fnc_randomPos = {
         private _roads = _cityPosition nearRoads ((_cityAreaSize select 0) max (_cityAreaSize select 1));
         private _randomRoadPos = getPos (selectRandom _roads);
         if (_emptyPosSearchRadius isEqualTo 0) exitWith {_randomRoadPos};
-        [[[_randomRoadPos, _emptyPosSearchRadius]]] call BIS_fnc_randomPos;
+        [[[_randomRoadPos, _emptyPosSearchRadius * 2]]] call BIS_fnc_randomPos;
     } else {
         [[[_cityPosition, [_cityAreaSize select 0, _cityAreaSize select 1, 0, true]]]] call BIS_fnc_randomPos;
     };

--- a/addons/civilian/functions/fnc_getCityRandomPos.sqf
+++ b/addons/civilian/functions/fnc_getCityRandomPos.sqf
@@ -1,0 +1,51 @@
+#include "script_component.hpp"
+/*
+ * Author: 3Mydlo3
+ * Function returns random position in given city.
+ *
+ * Arguments:
+ * 0: City namespace <CBA_NAMESPACE>
+ * 1: Object to fit in <OBJECT>
+ *
+ * Return Value:
+ * 0: Random position inside city <POSITION>
+ *
+ * Example:
+ * [] call afsk_common_fnc_getCityRandomPos
+ *
+ * Public: No
+ */
+
+params ["_cityNamespace", ["_object", objNull], ["_nearRoad", false], ["_emptyPosSearchRadius", 25]];
+
+private _cityPosition = _cityNamespace getVariable QGVAR(Position);
+private _cityArea = _cityNamespace getVariable QGVAR(cityArea);
+private _cityAreaSize = [_cityArea select 1 select 0, _cityArea select 1 select 1];
+
+private _fnc_randomPos = {
+    params ["_cityPosition", "_cityAreaSize", "_nearRoad"];
+    if (_nearRoad) then {
+        private _roads = _cityPosition nearRoads ((_cityAreaSize select 0) max (_cityAreaSize select 1));
+        private _randomRoadPos = getPos (selectRandom _roads);
+        if (_emptyPosSearchRadius isEqualTo 0) exitWith {_randomRoadPos};
+        [[[_cityPosition, _emptyPosSearchRadius]]] call BIS_fnc_randomPos;
+    } else {
+        [[[_cityPosition, [_cityAreaSize select 0, _cityAreaSize select 1, 0, true]]]] call BIS_fnc_randomPos;
+    };
+};
+
+if (_object isEqualTo objNull) exitWith {[_cityPosition, _cityAreaSize, _nearRoad] call _fnc_randomPos};
+
+private _location = _cityNamespace getVariable QGVAR(Location);
+
+private _randomPos = [0, 0, 0];
+private _loopLimit = 100;
+while {(_loopLimit >= 0) && {!(_randomPos isEqualTo []) && {!(_randomPos inArea _location)}}} do {
+    _randomPos = [_cityPosition, _cityAreaSize, _nearRoad] call _fnc_randomPos;
+    _randomPos = _randomPos findEmptyPosition [0, _emptyPosSearchRadius, _object];
+    _loopLimit = _loopLimit - 1;
+};
+
+if (_loopLimit isEqualTo 0) exitWith {[]};
+
+_randomPos;

--- a/addons/civilian/functions/fnc_getRandomPos.sqf
+++ b/addons/civilian/functions/fnc_getRandomPos.sqf
@@ -1,0 +1,65 @@
+#include "script_component.hpp"
+/*
+ * Author: 3Mydlo3
+ * Function returns random position on the map.
+ *
+ * Arguments:
+ * 0: Object (classname/config) to fit in <OBJECT/STRING/CONFIG>
+ * 1: Position must be near road <BOOL>
+ * 2: Search radius for empty position
+ *
+ * Return Value:
+ * 0: Random position on the map <POSITION>
+ *
+ * Example:
+ * [] call afsk_common_fnc_getRandomPos
+ *
+ * Public: No
+ */
+
+params [["_objectType", ""], ["_nearRoad", false], ["_emptyPosSearchRadius", 25]];
+
+// Function returns random position
+private _fnc_randomPos = {
+    params ["_nearRoad", "_emptyPosSearchRadius"];
+    if (_nearRoad) then {
+        private _randomPos = [];
+        while {_randomPos isEqualTo []} do {
+            private _randomMapPos = [] call BIS_fnc_randomPos;
+            private _roads = _randomMapPos nearRoads 100;
+            if (!(_roads isEqualTo [])) then {
+                private _randomRoadPos = getPos (selectRandom _roads);
+                if (_emptyPosSearchRadius isEqualTo 0) exitWith {_randomRoadPos};
+                _randomPos = [[[_randomRoadPos, _emptyPosSearchRadius * 2]]] call BIS_fnc_randomPos;
+            };
+        };
+        _randomPos
+    } else {
+        [] call BIS_fnc_randomPos;
+    };
+};
+
+if (!(_objectType isEqualType "")) then {
+    if (_objectType isEqualType configNull) then {
+        _objectType = configName _objectType;
+    };
+    if (_objectType isEqualType objNull) then {
+        _objectType = typeOf _objectType;
+    };
+};
+
+// If no object is given, just random position is enough
+if (_objectType isEqualTo "") exitWith {[_nearRoad, _emptyPosSearchRadius] call _fnc_randomPos};
+
+private _randomPos = [];
+private _loopLimit = 100;
+// Loop until acquired random empty pos is within location area (or loop limit reached)
+while {(_loopLimit >= 0) && {(_randomPos isEqualTo [])}} do {
+    _randomPos = [_nearRoad, _emptyPosSearchRadius] call _fnc_randomPos;
+    _randomPos = _randomPos findEmptyPosition [0, _emptyPosSearchRadius, _objectType];
+    _loopLimit = _loopLimit - 1;
+};
+
+if (_loopLimit isEqualTo 0) exitWith {[]};
+
+_randomPos;

--- a/addons/civilian/functions/fnc_initCity.sqf
+++ b/addons/civilian/functions/fnc_initCity.sqf
@@ -21,18 +21,25 @@ if (_cityLocation isEqualType configNull) then {
     _cityLocation = [getArray (_cityLocation >> 'position'), 10] call EFUNC(common,nearestLocation);
 };
 
+private _cityLocationConfig = (configFile >> "CfgWorlds" >> worldName >> "Names" >> className _cityLocation);
 
 // Create city namespace
 private _cityNamespace = true call CBA_fnc_createNamespace;
 GVAR(citiesLocations) setVariable [className _cityLocation, _cityNamespace, true];
 _cityNamespace setVariable [QGVAR(Location), _cityLocation, true];
 _cityNamespace setVariable [QGVAR(Name), [_cityLocation] call FUNC(getCityName), true];
+private _cityType = [_cityLocation] call EFUNC(common,getLocationType);
+_cityNamespace setVariable [QGVAR(cityType), _cityType, true];
+
+// Set city position and area variables
 private _cityPosition = (position _cityLocation);
 _cityPosition set [2, 0]; // Location position has negative third coordinate
 _cityNamespace setVariable [QGVAR(Position), _cityPosition, true];
-_cityNamespace setVariable [QGVAR(CiviliansList), []];
+private _cityArea = [_cityPosition, [getNumber (_cityLocationConfig >> 'radiusA'), getNumber (_cityLocationConfig >> 'radiusB'), 0, false]];
+_cityNamespace setVariable [QGVAR(cityArea), _cityArea];
 
-private _cityType = [_cityLocation] call EFUNC(common,getLocationType);
+// Create city civilians list
+_cityNamespace setVariable [QGVAR(CiviliansList), []];
 
 // Init civilians
 [_cityNamespace, _cityType] call FUNC(initCityCivilians);

--- a/addons/civilian/functions/fnc_initCityCivilians.sqf
+++ b/addons/civilian/functions/fnc_initCityCivilians.sqf
@@ -19,10 +19,10 @@
 params ["_cityNamespace", "_cityType"];
 
 private _cityCiviliansCount = switch (_cityType) do {
-    case "NameCityCapital": {ceil (random (10))};
-    case "NameCity": {ceil (random (8))};
-    case "NameVillage": {ceil (random (6))};
-    default {ceil (random (4))};
+    case "NameCityCapital": {GVAR(weightCapital)};
+    case "NameCity": {GVAR(weightCity)};
+    case "NameVillage": {GVAR(weightVillage)};
+    default {GVAR(weightRural)};
 };
 
 private _cityCivilians = [];

--- a/addons/civilian/functions/fnc_initVehicles.sqf
+++ b/addons/civilian/functions/fnc_initVehicles.sqf
@@ -47,7 +47,7 @@ while {_i > 0} do {
     private _city = _cities selectRandomWeighted _weights;
     private _carType = selectRandom _civilianCarTypes;
     private _pos = if (_city isEqualTo "RuralArea") then {
-        [nil, ["water"]] call BIS_fnc_randomPos;
+        [_carType, true] call FUNC(getRandomPos);
     } else {
         private _pos = [_city, _carType, true] call FUNC(getCityRandomPos);
         if (_pos isEqualTo []) then {

--- a/addons/civilian/functions/fnc_initVehicles.sqf
+++ b/addons/civilian/functions/fnc_initVehicles.sqf
@@ -36,6 +36,12 @@ private _weights = [];
 _cities pushBack "RuralArea";
 _weights pushBack (ceil (random (10)));
 
+private _civilianCarTypes = "( (getNumber (_x >> 'scope') >= 2)
+                                    && {
+                                        getText (_x >> 'vehicleClass') in ['Car']
+                                        && {getNumber (_x >> 'side') == 3}
+                                    })" configClasses (configFile >> "CfgVehicles");
+
 while {_i > 0} do {
     private _city = _cities selectRandomWeighted _weights;
     private _pos = if (_city isEqualTo "RuralArea") then {
@@ -43,6 +49,6 @@ while {_i > 0} do {
     } else {
         [_city] call FUNC(getCityRandomPos);
     };
-    ["C_Offroad_01_F", _pos] call FUNC(createVehicle);
+    [selectRandom _civilianCarTypes, _pos] call FUNC(createVehicle);
     _i = _i - 1;
 };

--- a/addons/civilian/functions/fnc_initVehicles.sqf
+++ b/addons/civilian/functions/fnc_initVehicles.sqf
@@ -43,6 +43,8 @@ private _civilianCarTypes = "( (getNumber (_x >> 'scope') >= 2)
                                         && {getNumber (_x >> 'side') == 3}
                                     })" configClasses (configFile >> "CfgVehicles");
 
+GVAR(citiesVehicles) = call CBA_fnc_createNamespace;
+
 while {_i > 0} do {
     private _city = _cities selectRandomWeighted _weights;
     private _carType = selectRandom _civilianCarTypes;
@@ -56,7 +58,20 @@ while {_i > 0} do {
         _pos
     };
     if (!(_pos isEqualTo [])) then {
-        [_carType, _pos] call FUNC(createVehicle);
+        private _vehicle = [_carType, _pos] call FUNC(createVehicle);
+        if (_city isEqualTo "RuralArea") then {
+            private _list = GVAR(citiesVehicles) getVariable ["RuralArea", []];
+            _list pushBack _vehicle;
+            GVAR(citiesVehicles) setVariable ["RuralArea", _list];
+        } else {
+            private _list = GVAR(citiesVehicles) getVariable [[_city] call FUNC(getCityName), []];
+            if (count _list > 10) then {
+                GVAR(citiesVehicles) setVariable [[_city] call FUNC(getCityName), nil];
+                private _index = (_cities findIf {_x isEqualTo _city});
+                _cities deleteAt _index;
+                _weights deleteAt _index;
+            };
+        };
         _i = _i - 1;
     };
 };

--- a/addons/civilian/functions/fnc_initVehicles.sqf
+++ b/addons/civilian/functions/fnc_initVehicles.sqf
@@ -1,0 +1,48 @@
+#include "script_component.hpp"
+/*
+ * Author: 3Mydlo3
+ * Function initializes empty civilian vehicles on the map.
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * None
+ *
+ * Public: No
+ */
+
+private _i = GVAR(emptyVehiclesLimit);
+
+private _cities = +GVAR(cities);
+private _weights = [];
+
+//
+{
+    private _cityType = _x getVariable QGVAR(cityType);
+    _cityWeight = switch (_cityType) do {
+        case "NameCityCapital": {ceil (random (10))};
+        case "NameCity": {ceil (random (8))};
+        case "NameVillage": {ceil (random (6))};
+        default {ceil (random (4))};
+    };
+    _weights pushBack (_cityWeight);
+} forEach _cities;
+
+// Add entry for non city area
+_cities pushBack "RuralArea";
+_weights pushBack (ceil (random (10)));
+
+while {_i > 0} do {
+    private _city = _cities selectRandomWeighted _weights;
+    private _pos = if (_city isEqualTo "RuralArea") then {
+        [nil, ["water"]] call BIS_fnc_randomPos;
+    } else {
+        [_city] call FUNC(getCityRandomPos);
+    };
+    ["C_Offroad_01_F", _pos] call FUNC(createVehicle);
+    _i = _i - 1;
+};

--- a/addons/civilian/functions/fnc_initVehicles.sqf
+++ b/addons/civilian/functions/fnc_initVehicles.sqf
@@ -20,7 +20,7 @@ private _i = GVAR(emptyVehiclesLimit);
 private _cities = +GVAR(cities);
 private _weights = [];
 
-//
+// Create weights array for cities
 {
     private _cityType = _x getVariable QGVAR(cityType);
     _cityWeight = switch (_cityType) do {
@@ -36,6 +36,7 @@ private _weights = [];
 _cities pushBack "RuralArea";
 _weights pushBack GVAR(weightRural);
 
+// Retrieve all civilian car types from config
 private _civilianCarTypes = "( (getNumber (_x >> 'scope') >= 2)
                                     && {
                                         getText (_x >> 'vehicleClass') in ['Car']

--- a/addons/civilian/functions/fnc_initVehicles.sqf
+++ b/addons/civilian/functions/fnc_initVehicles.sqf
@@ -24,17 +24,17 @@ private _weights = [];
 {
     private _cityType = _x getVariable QGVAR(cityType);
     _cityWeight = switch (_cityType) do {
-        case "NameCityCapital": {ceil (random (10))};
-        case "NameCity": {ceil (random (8))};
-        case "NameVillage": {ceil (random (6))};
-        default {ceil (random (4))};
+        case "NameCityCapital": {GVAR(weightCapital)};
+        case "NameCity": {GVAR(weightCity)};
+        case "NameVillage": {GVAR(weightVillage)};
+        default {GVAR(weightRural)};
     };
     _weights pushBack (_cityWeight);
 } forEach _cities;
 
 // Add entry for non city area
 _cities pushBack "RuralArea";
-_weights pushBack (ceil (random (10)));
+_weights pushBack GVAR(weightRural);
 
 private _civilianCarTypes = "( (getNumber (_x >> 'scope') >= 2)
                                     && {

--- a/addons/civilian/functions/fnc_initVehicles.sqf
+++ b/addons/civilian/functions/fnc_initVehicles.sqf
@@ -17,25 +17,6 @@
 
 private _i = GVAR(emptyVehiclesLimit);
 
-private _cities = +GVAR(cities);
-private _weights = [];
-
-// Create weights array for cities
-{
-    private _cityType = _x getVariable QGVAR(cityType);
-    _cityWeight = switch (_cityType) do {
-        case "NameCityCapital": {GVAR(weightCapital)};
-        case "NameCity": {GVAR(weightCity)};
-        case "NameVillage": {GVAR(weightVillage)};
-        default {GVAR(weightRural)};
-    };
-    _weights pushBack (_cityWeight);
-} forEach _cities;
-
-// Add entry for non city area
-_cities pushBack "RuralArea";
-_weights pushBack GVAR(weightRural);
-
 // Retrieve all civilian car types from config
 private _civilianCarTypes = "( (getNumber (_x >> 'scope') >= 2)
                                     && {
@@ -46,7 +27,6 @@ private _civilianCarTypes = "( (getNumber (_x >> 'scope') >= 2)
 GVAR(citiesVehicles) = call CBA_fnc_createNamespace;
 
 while {_i > 0} do {
-    private _city = _cities selectRandomWeighted _weights;
     private _carType = selectRandom _civilianCarTypes;
     private _pos = [_carType, true, false, true] call FUNC(getRandomPos);
     if (!(_pos isEqualTo [])) then {

--- a/addons/civilian/functions/fnc_initVehicles.sqf
+++ b/addons/civilian/functions/fnc_initVehicles.sqf
@@ -45,11 +45,18 @@ private _civilianCarTypes = "( (getNumber (_x >> 'scope') >= 2)
 
 while {_i > 0} do {
     private _city = _cities selectRandomWeighted _weights;
+    private _carType = selectRandom _civilianCarTypes;
     private _pos = if (_city isEqualTo "RuralArea") then {
         [nil, ["water"]] call BIS_fnc_randomPos;
     } else {
-        [_city] call FUNC(getCityRandomPos);
+        private _pos = [_city, _carType, true] call FUNC(getCityRandomPos);
+        if (_pos isEqualTo []) then {
+            _pos = [_city, _carType] call FUNC(getCityRandomPos);
+        };
+        _pos
     };
-    [selectRandom _civilianCarTypes, _pos] call FUNC(createVehicle);
-    _i = _i - 1;
+    if (!(_pos isEqualTo [])) then {
+        [_carType, _pos] call FUNC(createVehicle);
+        _i = _i - 1;
+    };
 };

--- a/addons/civilian/functions/fnc_initVehicles.sqf
+++ b/addons/civilian/functions/fnc_initVehicles.sqf
@@ -48,30 +48,9 @@ GVAR(citiesVehicles) = call CBA_fnc_createNamespace;
 while {_i > 0} do {
     private _city = _cities selectRandomWeighted _weights;
     private _carType = selectRandom _civilianCarTypes;
-    private _pos = if (_city isEqualTo "RuralArea") then {
-        [_carType, true] call FUNC(getRandomPos);
-    } else {
-        private _pos = [_city, _carType, true] call FUNC(getCityRandomPos);
-        if (_pos isEqualTo []) then {
-            _pos = [_city, _carType] call FUNC(getCityRandomPos);
-        };
-        _pos
-    };
+    private _pos = [_carType, true, false, true] call FUNC(getRandomPos);
     if (!(_pos isEqualTo [])) then {
         private _vehicle = [_carType, _pos] call FUNC(createVehicle);
-        if (_city isEqualTo "RuralArea") then {
-            private _list = GVAR(citiesVehicles) getVariable ["RuralArea", []];
-            _list pushBack _vehicle;
-            GVAR(citiesVehicles) setVariable ["RuralArea", _list];
-        } else {
-            private _list = GVAR(citiesVehicles) getVariable [[_city] call FUNC(getCityName), []];
-            if (count _list > 10) then {
-                GVAR(citiesVehicles) setVariable [[_city] call FUNC(getCityName), nil];
-                private _index = (_cities findIf {_x isEqualTo _city});
-                _cities deleteAt _index;
-                _weights deleteAt _index;
-            };
-        };
         _i = _i - 1;
     };
 };

--- a/addons/civilian/functions/fnc_initVehicles.sqf
+++ b/addons/civilian/functions/fnc_initVehicles.sqf
@@ -30,6 +30,14 @@ while {_i > 0} do {
     private _carType = selectRandom _civilianCarTypes;
     private _pos = [_carType, true, false, true] call FUNC(getRandomPos);
     if (!(_pos isEqualTo [])) then {
+        // Check if there are other vehicles nearby to prevent creating too much vehicles in one area
+        private _distance = 100 * (4 - GVAR(emptyVehiclesLimitMultiplier));
+        private _nearbyCars = _pos nearObjects ["Car", _distance];
+        private _nearbyCarsCount = count (_nearbyCars select {_pos distance _x < (_distance / 4)});
+        if (_nearbyCarsCount >= 1 && {(random 1) > 0.1}) exitWith {};
+        private _nearbyCarsCount = count (_nearbyCars select {_pos distance _x < _distance});
+        if (_nearbyCarsCount >= 2 && {(random 1) > 0.1}) exitWith {};
+        // Create vehicle on given position. We need some way to prevent instant damage to vehicle as these empty positions are not perfect.
         private _vehicle = [_carType, _pos] call FUNC(createVehicle);
         _i = _i - 1;
     };

--- a/addons/civilian/functions/fnc_isHouseNearby.sqf
+++ b/addons/civilian/functions/fnc_isHouseNearby.sqf
@@ -1,0 +1,25 @@
+#include "script_component.hpp"
+/*
+ * Author: 3Mydlo3
+ * Function checks if there is any house nearby.
+ *
+ * Arguments:
+ * 0: Position to check <POSITION>
+ *
+ * Return Value:
+ * 0: Result <BOOL>
+ *
+ * Example:
+ * [position player] call afsk_civilian_fnc_isHouseNearby
+ *
+ * Public: No
+ */
+
+params ["_position"];
+
+private _houses = nearestTerrainObjects [_position, ["House"], 50, false];
+if (_houses isEqualTo []) then {
+    false
+} else {
+    true
+};

--- a/addons/civilian/functions/fnc_isRoadNearby.sqf
+++ b/addons/civilian/functions/fnc_isRoadNearby.sqf
@@ -1,0 +1,25 @@
+#include "script_component.hpp"
+/*
+ * Author: 3Mydlo3
+ * Function checks if there is any road nearby.
+ *
+ * Arguments:
+ * 0: Position to check <POSITION>
+ *
+ * Return Value:
+ * 0: Result <BOOL>
+ *
+ * Example:
+ * [position player] call afsk_civilian_fnc_isRoadNearby
+ *
+ * Public: No
+ */
+
+params ["_position"];
+
+private _roads = _position nearRoads 50;
+if (_roads isEqualTo []) then {
+    false
+} else {
+    true
+};

--- a/addons/civilian/functions/fnc_setVehicleRandomTexture.sqf
+++ b/addons/civilian/functions/fnc_setVehicleRandomTexture.sqf
@@ -1,0 +1,37 @@
+#include "script_component.hpp"
+/*
+ * Author: 3Mydlo3
+ * Function sets global texture (if possible) for given vehicle.
+ *
+ * Arguments:
+ * 0: Vehicle to set its texture <OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [vehicle player] call afsk_civilian_fnc_setVehicleRandomTexture
+ *
+ * Public: No
+ */
+
+params ["_vehicle"];
+
+private _vehicleClassname = typeOf _vehicle;
+private _vehicleConfig = (configFile >> "CfgVehicles" >> _vehicleClassname);
+
+// Retrieve all available textures for given vehicle
+private _textureConfigs = "true" configClasses (_vehicleConfig >> "TextureSources");
+private _vehicleTextures = [];
+{
+    private _textures = getArray (_x >> "textures");
+    _vehicleTextures pushBack (_textures);
+} forEach _textureConfigs;
+
+// Select random texture and apply globally for all selections
+private _randomTexture = selectRandom _vehicleTextures;
+private _selection = 0;
+{
+    _vehicle setObjectTextureGlobal [_selection, _x];
+    _selection = _selection + 1;
+} forEach _randomTexture;

--- a/addons/civilian/initSettings.sqf
+++ b/addons/civilian/initSettings.sqf
@@ -5,7 +5,7 @@
     "LIST",
     [LSTRING(EmptyVehiclesLimit), LSTRING(EmptyVehiclesLimit_Description)],
     LSTRING(DisplayName),
-    [[1, 2, 3], [LSTRING(Low), LSTRING(Medium), LSTRING(High)], 2],
+    [[1, 2, 3], [LSTRING(Low), LSTRING(Medium), LSTRING(High)], 1],
     true,
     {},
     true

--- a/addons/civilian/initSettings.sqf
+++ b/addons/civilian/initSettings.sqf
@@ -1,0 +1,12 @@
+#include "script_component.hpp"
+
+[
+    QGVAR(emptyVehiclesLimitMultiplier),
+    "LIST",
+    [LSTRING(EmptyVehiclesLimit), LSTRING(EmptyVehiclesLimit_Description)],
+    LSTRING(DisplayName),
+    [[1, 2, 3], [LSTRING(Low), LSTRING(Medium), LSTRING(High)], 2],
+    true,
+    {},
+    true
+] call CBA_fnc_addSetting;

--- a/addons/civilian/stringtable.xml
+++ b/addons/civilian/stringtable.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project name="AFSK">
+    <Package name="Civilian">
+        <Key ID="STR_AFSK_Civilian_DisplayName">
+            <English>SerialKillers - Civilian</English>
+            <Polish>SerialKillers - Cywile</Polish>
+        </Key>
+        <Key ID="STR_AFSK_Civilian_EmptyVehiclesLimit">
+            <English>Civilian vehicles limit</English>
+            <Polish>Limit pojazdów cywilnych</Polish>
+        </Key>
+        <Key ID="STR_AFSK_Civilian_EmptyVehiclesLimit_Description">
+            <English>Controls how much civilian vehicles will be created on the whole map.</English>
+            <Polish>Ustala jak dużo pojazdów cywilnych będzie utworzonych na całej mapie.</Polish>
+        </Key>
+        <Key ID="STR_AFSK_Civilian_Low">
+            <English>Low</English>
+            <Polish>Mało</Polish>
+        </Key>
+        <Key ID="STR_AFSK_Civilian_Medium">
+            <English>Mediun</English>
+            <Polish>Średnio</Polish>
+        </Key>
+        <Key ID="STR_AFSK_Civilian_High">
+            <English>High</English>
+            <Polish>Dużo</Polish>
+        </Key>
+    </Package>
+</Project>


### PR DESCRIPTION
**When merged this pull request will:**
- [x] Add automatic civilian vehicles
- [x] Add `EFUNC(civilian,getCityRandomPos)`
- [x] Add `EFUNC(civilian,setVehicleRandomTexture)` which sets vehicle texture globally, ensuring that all players can see the same color
- [x] Add some new area variables to city namespaces
- [x] Add setting for civilian vehicle quantity multiplier
- [x] Disallow overvehicling location (too much vehicles in area)
- [x] Create vehicles near buildings and roads (but not on them) instead of total random
- [x] Automatic vehicle limit based on map size and number of locations

<details>
  <summary>Images</summary>
Civilian dots are green, vehicle dots are dark yellow.

![obraz](https://user-images.githubusercontent.com/30000580/71559764-7a957c00-2a62-11ea-8c30-58c3f59ec917.png)

</details>

Closes #7 