### PR TITLE
Automatic generation of killers starting position

### DIFF
--- a/addons/civilian/functions/fnc_getRandomPos.sqf
+++ b/addons/civilian/functions/fnc_getRandomPos.sqf
@@ -19,48 +19,5 @@
  * Public: No
  */
 
-params [["_objectType", ""], ["_nearRoad", false], ["_allowOnRoad", true], ["_nearHouse", false], ["_emptyPosSearchRadius", 25]];
-
-// Function returns random position
-private _fnc_randomPos = {
-    params ["_nearRoad", "_allowOnRoad", "_nearHouse"];
-    private _randomPos = [];
-    while {_randomPos isEqualTo []} do {
-        _randomPos = [] call BIS_fnc_randomPos;
-        if (!(_randomPos isEqualTo []) && {_nearHouse && {!([_randomPos] call FUNC(isHouseNearby))}}) then {
-            _randomPos = [];
-        };
-        if (!(_randomPos isEqualTo []) && {!(_allowOnRoad) && {isOnRoad _randomPos}}) then {
-            _randomPos = [];
-        };
-        if (!(_randomPos isEqualTo []) && {_nearRoad && {!([_randomPos] call FUNC(isRoadNearby))}}) then {
-            _randomPos = [];
-        };
-    };
-    _randomPos
-};
-
-if (!(_objectType isEqualType "")) then {
-    if (_objectType isEqualType configNull) then {
-        _objectType = configName _objectType;
-    };
-    if (_objectType isEqualType objNull) then {
-        _objectType = typeOf _objectType;
-    };
-};
-
-// If no object is given, just random position is enough
-if (_objectType isEqualTo "") exitWith {[_nearRoad, _allowOnRoad, _nearHouse] call _fnc_randomPos};
-
-private _randomPos = [];
-private _loopLimit = 250;
-// Loop until acquired random empty pos is within location area (or loop limit reached)
-while {(_loopLimit >= 0) && {(_randomPos isEqualTo [])}} do {
-    _randomPos = [_nearRoad, _allowOnRoad, _nearHouse] call _fnc_randomPos;
-    _randomPos = _randomPos findEmptyPosition [0, _emptyPosSearchRadius, _objectType];
-    _loopLimit = _loopLimit - 1;
-};
-
-if (_loopLimit isEqualTo 0) exitWith {[]};
-
-_randomPos;
+// For now for compatibility, will remove this function later on
+_this call EFUNC(common,getRandomPos)

--- a/addons/common/XEH_PREP.hpp
+++ b/addons/common/XEH_PREP.hpp
@@ -7,6 +7,7 @@ PREP(getLocationType);
 PREP(getNearestCityLocation);
 PREP(getNearestLocation);
 PREP(getNearestLocationName);
+PREP(getNearestLocationWithAvailableName);
 PREP(getRandomEmptyPosition);
 PREP(getRandomPos);
 PREP(playMusicServer);

--- a/addons/common/XEH_PREP.hpp
+++ b/addons/common/XEH_PREP.hpp
@@ -8,6 +8,7 @@ PREP(getNearestCityLocation);
 PREP(getNearestLocation);
 PREP(getNearestLocationName);
 PREP(getRandomEmptyPosition);
+PREP(getRandomPos);
 PREP(playMusicServer);
 PREP(removeItemsFromArsenal);
 PREP(showMessage);

--- a/addons/common/functions/fnc_getLocationName.sqf
+++ b/addons/common/functions/fnc_getLocationName.sqf
@@ -17,7 +17,11 @@
 
 params ["_location"];
 
-private _locationClassname = className _location;
+private _locationClassname = if (_location isEqualType locationNull) then {
+    className _location;
+} else {
+    _location
+};
 // Try to get name from cache
 private _name = GVAR(locationNames) getVariable [_locationClassname, ""];
 

--- a/addons/common/functions/fnc_getLocationName.sqf
+++ b/addons/common/functions/fnc_getLocationName.sqf
@@ -22,11 +22,15 @@ private _locationClassname = if (_location isEqualType locationNull) then {
 } else {
     _location
 };
+
+// Location does not have classname so no name also
+if (_locationClassname isEqualTo "") exitWith {""};
+
 // Try to get name from cache
 private _name = GVAR(locationNames) getVariable [_locationClassname, ""];
 
 if (_name isEqualTo "") then {
-    _name = getText (configFile >> "CfgWorlds" >> worldName >> "Names" >> className _location >> "name");
+    _name = getText (configFile >> "CfgWorlds" >> worldName >> "Names" >> _locationClassname >> "name");
     // Fill cache
     GVAR(locationNames) setVariable [_locationClassname, _name];
 };

--- a/addons/common/functions/fnc_getNearestLocationName.sqf
+++ b/addons/common/functions/fnc_getNearestLocationName.sqf
@@ -4,7 +4,7 @@
  * Function returns name of nearest map location for given position/unit.
  *
  * Arguments:
- * 0: Unit/position to find nearest map location name <UNIT/POSITION/LOCATION>
+ * 0: Object/position to find nearest map location name <OBJECT/POSITION/LOCATION>
  * 1: Location search radius
  *
  * Return Value:
@@ -17,6 +17,14 @@
  */
 
 params ["_pos", ["_searchRadius", 2000]];
+
+if (_pos isEqualType locationNull) then {
+    _pos = position _pos;
+};
+
+if (_pos isEqualType objNull) then {
+    _pos = getPosATL _pos;
+};
 
 // Get nearest location
 private _nearestLocation = [_pos, _searchRadius] call FUNC(getNearestLocation);

--- a/addons/common/functions/fnc_getNearestLocationWithAvailableName.sqf
+++ b/addons/common/functions/fnc_getNearestLocationWithAvailableName.sqf
@@ -1,0 +1,39 @@
+#include "script_component.hpp"
+/*
+ * Author: 3Mydlo3
+ * Function returns nearest map location which has available name for given position/unit.
+ *
+ * Arguments:
+ * 0: Unit/position to find nearest map location with name <UNIT/POSITION/LOCATION>
+ * 1: Location search radius
+ *
+ * Return Value:
+ * 0: Nearest map available location with name <LOCATION>
+ *
+ * Example:
+ * [player] call afsk_common_fnc_getNearestLocationWithAvailableName
+ *
+ * Public: No
+ */
+
+params ["_pos", ["_searchRadius", 2000]];
+
+if (_pos isEqualType locationNull) then {
+    _pos = position _pos;
+};
+
+if (_pos isEqualType objNull) then {
+    _pos = getPosATL _pos;
+};
+
+// Get nearest locations
+private _locations = nearestLocations [_pos, GVAR(allLocationTypes), _searchRadius];
+
+// Loop through all locations and find nearest with name
+private _location = locationNull;
+{
+    private _locationName = [_x] call FUNC(getLocationName);
+    if (!(_locationName isEqualTo "")) exitWith {_location = _x};
+} forEach _locations;
+
+_location

--- a/addons/common/functions/fnc_getRandomPos.sqf
+++ b/addons/common/functions/fnc_getRandomPos.sqf
@@ -1,0 +1,66 @@
+#include "script_component.hpp"
+/*
+ * Author: 3Mydlo3
+ * Function returns random position on the map.
+ *
+ * Arguments:
+ * 0: Object (classname/config) to fit in <OBJECT/STRING/CONFIG>
+ * 1: Position must be near road <BOOL>
+ * 2: Position can be on road <BOOL>
+ * 3: Position must be near house <BOOL>
+ * 4: Search radius for empty position <NUMBER>
+ *
+ * Return Value:
+ * 0: Random position on the map <POSITION>
+ *
+ * Example:
+ * [] call afsk_common_fnc_getRandomPos
+ *
+ * Public: No
+ */
+
+params [["_objectType", ""], ["_nearRoad", false], ["_allowOnRoad", true], ["_nearHouse", false], ["_emptyPosSearchRadius", 25]];
+
+// Function returns random position
+private _fnc_randomPos = {
+    params ["_nearRoad", "_allowOnRoad", "_nearHouse"];
+    private _randomPos = [];
+    while {_randomPos isEqualTo []} do {
+        _randomPos = [] call BIS_fnc_randomPos;
+        if (!(_randomPos isEqualTo []) && {_nearHouse && {!([_randomPos] call FUNC(isHouseNearby))}}) then {
+            _randomPos = [];
+        };
+        if (!(_randomPos isEqualTo []) && {!(_allowOnRoad) && {isOnRoad _randomPos}}) then {
+            _randomPos = [];
+        };
+        if (!(_randomPos isEqualTo []) && {_nearRoad && {!([_randomPos] call FUNC(isRoadNearby))}}) then {
+            _randomPos = [];
+        };
+    };
+    _randomPos
+};
+
+if (!(_objectType isEqualType "")) then {
+    if (_objectType isEqualType configNull) then {
+        _objectType = configName _objectType;
+    };
+    if (_objectType isEqualType objNull) then {
+        _objectType = typeOf _objectType;
+    };
+};
+
+// If no object is given, just random position is enough
+if (_objectType isEqualTo "") exitWith {[_nearRoad, _allowOnRoad, _nearHouse] call _fnc_randomPos};
+
+private _randomPos = [];
+private _loopLimit = 250;
+// Loop until acquired random empty pos is within location area (or loop limit reached)
+while {(_loopLimit >= 0) && {(_randomPos isEqualTo [])}} do {
+    _randomPos = [_nearRoad, _allowOnRoad, _nearHouse] call _fnc_randomPos;
+    _randomPos = _randomPos findEmptyPosition [0, _emptyPosSearchRadius, _objectType];
+    _loopLimit = _loopLimit - 1;
+};
+
+if (_loopLimit isEqualTo 0) exitWith {[]};
+
+_randomPos;

--- a/addons/killers/XEH_PREP.hpp
+++ b/addons/killers/XEH_PREP.hpp
@@ -4,5 +4,6 @@ PREP(deleteStartPositionsMarkers);
 PREP(fillKillersStash);
 PREP(initKillersBase);
 PREP(initKillersStashes);
+PREP(initStartPositions);
 PREP(killerKilled);
 PREP(killerRespawned);

--- a/addons/killers/XEH_postInit.sqf
+++ b/addons/killers/XEH_postInit.sqf
@@ -13,9 +13,18 @@
     _caller setPos _destination;
 }] call CBA_fnc_addEventHandler;
 
+// Start positions markers array for easy deletion after teleportation
+GVAR(startPositionsMarkers) = [];
 if (isServer) then {
     call FUNC(initKillersBase);
     call FUNC(initKillersStashes);
+    // Random number of start positions if 0 or -1
+    if (GVAR(startPositionsCount) <= 0) then {
+        GVAR(startPositionsCount) = ceil (random [10, 15, 20]);
+    };
+    // Namespace containing location name - position connection
+    GVAR(startPositions) = call FUNC(initStartPositions);
+    publicVariable QGVAR(startPositions);
 };
 
 if (hasInterface) then {

--- a/addons/killers/XEH_postInit.sqf
+++ b/addons/killers/XEH_postInit.sqf
@@ -10,7 +10,7 @@
 
 [QGVAR(teleport), {
     params ["_teleporter", "_caller", "_destination"];
-    _caller setPos (getPos _destination);
+    _caller setPos _destination;
 }] call CBA_fnc_addEventHandler;
 
 if (isServer) then {

--- a/addons/killers/XEH_preInit.sqf
+++ b/addons/killers/XEH_preInit.sqf
@@ -11,6 +11,7 @@ if (isServer) then {
     if (GVAR(startPositionsCount) <= 0) then {
         GVAR(startPositionsCount) = ceil (random [10, 15, 20]);
     };
+    // Namespace containing location name - position connection
     GVAR(startPositions) = call FUNC(initStartPositions);
     publicVariable QGVAR(startPositions);
 };

--- a/addons/killers/XEH_preInit.sqf
+++ b/addons/killers/XEH_preInit.sqf
@@ -4,7 +4,8 @@ ADDON = false;
 
 #include "initSettings.sqf"
 
-GVAR(killersStartPositionsMarkers) = [];
+// Start positions markers array for easy deletion after teleportation
+GVAR(startPositionsMarkers) = [];
 if (isServer) then {
     // Random number of start positions if 0 or -1
     if (GVAR(startPositionsCount) <= 0) then {

--- a/addons/killers/XEH_preInit.sqf
+++ b/addons/killers/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 ADDON = false;
 #include "XEH_PREP.hpp"
 
+#include "initSettings.sqf"
+
 GVAR(killersStartPositionsMarkers) = [];
 
 ADDON = true;

--- a/addons/killers/XEH_preInit.sqf
+++ b/addons/killers/XEH_preInit.sqf
@@ -5,5 +5,7 @@ ADDON = false;
 #include "initSettings.sqf"
 
 GVAR(killersStartPositionsMarkers) = [];
+GVAR(startPositions) = call FUNC(initStartPositions);
+publicVariable QGVAR(startPositions);
 
 ADDON = true;

--- a/addons/killers/XEH_preInit.sqf
+++ b/addons/killers/XEH_preInit.sqf
@@ -4,16 +4,4 @@ ADDON = false;
 
 #include "initSettings.sqf"
 
-// Start positions markers array for easy deletion after teleportation
-GVAR(startPositionsMarkers) = [];
-if (isServer) then {
-    // Random number of start positions if 0 or -1
-    if (GVAR(startPositionsCount) <= 0) then {
-        GVAR(startPositionsCount) = ceil (random [10, 15, 20]);
-    };
-    // Namespace containing location name - position connection
-    GVAR(startPositions) = call FUNC(initStartPositions);
-    publicVariable QGVAR(startPositions);
-};
-
 ADDON = true;

--- a/addons/killers/XEH_preInit.sqf
+++ b/addons/killers/XEH_preInit.sqf
@@ -5,7 +5,13 @@ ADDON = false;
 #include "initSettings.sqf"
 
 GVAR(killersStartPositionsMarkers) = [];
-GVAR(startPositions) = call FUNC(initStartPositions);
-publicVariable QGVAR(startPositions);
+if (isServer) then {
+    // Random number of start positions if 0 or -1
+    if (GVAR(startPositionsCount) <= 0) then {
+        GVAR(startPositionsCount) = ceil (random [10, 15, 20]);
+    };
+    GVAR(startPositions) = call FUNC(initStartPositions);
+    publicVariable QGVAR(startPositions);
+};
 
 ADDON = true;

--- a/addons/killers/functions/fnc_createStartPositionMarker.sqf
+++ b/addons/killers/functions/fnc_createStartPositionMarker.sqf
@@ -1,13 +1,14 @@
 #include "script_component.hpp"
 /*
  * Author: 3Mydlo3
- * Function creates markers for given killers start position module.
+ * Function creates marker for given killers start position.
  *
  * Arguments:
- * 0: Killers start position module <OBJECT>
+ * 0: Start position <POSITION>
+ * 1: Position nearest location name <STRING>
  *
  * Return Value:
- * None
+ * 0: Created marker <STRING>
  *
  * Example:
  * None
@@ -15,12 +16,17 @@
  * Public: No
  */
 
-params ["_module"];
+params ["_pos", ["_name", ""]];
 
-private _moduleLocationName = _module getVariable ["LocationName", "Teleport"];
-private _marker = createMarkerlocal [_moduleLocationName, getPos _module];
+if (_name isEqualTo "") then {
+    _name = [_pos] call EFUNC(common,getNearestLocationName);
+};
+
+private _marker = createMarkerlocal [_name, _pos];
 _marker setMarkerColorlocal "ColorEAST";
 _marker setMarkerSizelocal [0.5,0.5];
 _marker setMarkerTypelocal "mil_end";
-_marker setMarkerTextLocal _moduleLocationName;
+_marker setMarkerTextLocal _name;
 GVAR(killersStartPositionsMarkers) pushback _marker;
+
+_marker

--- a/addons/killers/functions/fnc_createStartPositionMarker.sqf
+++ b/addons/killers/functions/fnc_createStartPositionMarker.sqf
@@ -27,6 +27,6 @@ _marker setMarkerColorlocal "ColorEAST";
 _marker setMarkerSizelocal [0.5,0.5];
 _marker setMarkerTypelocal "mil_end";
 _marker setMarkerTextLocal _name;
-GVAR(killersStartPositionsMarkers) pushback _marker;
+GVAR(startPositionsMarkers) pushback _marker;
 
 _marker

--- a/addons/killers/functions/fnc_createTeleport.sqf
+++ b/addons/killers/functions/fnc_createTeleport.sqf
@@ -20,8 +20,8 @@ params ["_flag"];
 private _teleportActionsIDs = [];
 private _positionID = 0;
 {
-    // _x is location className and value is position assigned
-    private _destinationName = format ["%1 - %2", _positionID, [_x] call EFUNC(common,getLocationName)];
+    // _x is location name and value is position assigned
+    private _destinationName = format ["%1 - %2", _positionID, _x];
     private _destinationPos = GVAR(startPositions) getVariable _x;
     private _teleportActionID = _flag addAction [_destinationName, {
         [QGVAR(teleport), [_this select 0, _this select 1, _this select 3 select 0]] call CBA_fnc_serverEvent;

--- a/addons/killers/functions/fnc_createTeleport.sqf
+++ b/addons/killers/functions/fnc_createTeleport.sqf
@@ -19,17 +19,21 @@ params ["_flag"];
 
 private _teleportActionsIDs = [];
 {
-    private _destinationName = _x getVariable ["LocationName", "Teleport"];
+    // _x is location className and value is position assigned
+    private _destinationName = [_x] call EFUNC(common,getLocationName);
+    private _destinationPos = GVAR(startPositions) getVariable _x;
     private _teleportActionID = _flag addAction [_destinationName, {
         [QGVAR(teleport), [_this select 0, _this select 1, _this select 3 select 0]] call CBA_fnc_serverEvent;
+        // Delete all teleport actions and markers
         call FUNC(deleteStartPositionsMarkers);
         private _teleportActionsIDs = (_this select 0) getVariable [QGVAR(teleportActionsIDs), []];
         {
             (_this select 0 ) removeAction (_x);
         } forEach _teleportActionsIDs;
-    }, [_x]];
-    [_x] call FUNC(createStartPositionMarker);
+    }, [_destinationPos]];
+    [_destinationPos, _destinationName] call FUNC(createStartPositionMarker);
+    // Add for deletion after teleportation
     _teleportActionsIDs pushBack _teleportActionID;
-} forEach EGVAR(modules,killersStartPositions);
+} forEach (allVariables GVAR(startPositions));
 
 _flag setVariable [QGVAR(teleportActionsIDs), _teleportActionsIDs];

--- a/addons/killers/functions/fnc_createTeleport.sqf
+++ b/addons/killers/functions/fnc_createTeleport.sqf
@@ -18,9 +18,10 @@
 params ["_flag"];
 
 private _teleportActionsIDs = [];
+private _positionID = 0;
 {
     // _x is location className and value is position assigned
-    private _destinationName = [_x] call EFUNC(common,getLocationName);
+    private _destinationName = format ["%1 - %2", _positionID, [_x] call EFUNC(common,getLocationName)];
     private _destinationPos = GVAR(startPositions) getVariable _x;
     private _teleportActionID = _flag addAction [_destinationName, {
         [QGVAR(teleport), [_this select 0, _this select 1, _this select 3 select 0]] call CBA_fnc_serverEvent;
@@ -34,6 +35,7 @@ private _teleportActionsIDs = [];
     [_destinationPos, _destinationName] call FUNC(createStartPositionMarker);
     // Add for deletion after teleportation
     _teleportActionsIDs pushBack _teleportActionID;
+    _positionID = _positionID + 1;
 } forEach (allVariables GVAR(startPositions));
 
 _flag setVariable [QGVAR(teleportActionsIDs), _teleportActionsIDs];

--- a/addons/killers/functions/fnc_deleteStartPositionsMarkers.sqf
+++ b/addons/killers/functions/fnc_deleteStartPositionsMarkers.sqf
@@ -17,4 +17,5 @@
 
 {
     deleteMarkerLocal _x;
-} forEach GVAR(killersStartPositionsMarkers);
+} forEach GVAR(startPositionsMarkers);
+GVAR(startPositionsMarkers) = [];

--- a/addons/killers/functions/fnc_initStartPositions.sqf
+++ b/addons/killers/functions/fnc_initStartPositions.sqf
@@ -20,6 +20,7 @@
 private _i = GVAR(startPositionsCount);
 private _positions = call CBA_fnc_createNamespace;
 
+// Generate positions
 while {_i > 0} do {
     private _pos = [nil, false, false, true] call EFUNC(common,getRandomPos);
     //diag_log format ["[AFSK] [KILLERS] [initStartPositions] Pos: %1", _pos];

--- a/addons/killers/functions/fnc_initStartPositions.sqf
+++ b/addons/killers/functions/fnc_initStartPositions.sqf
@@ -41,4 +41,19 @@ while {_i > 0} do {
     };
 };
 
+// Load any start position modules
+{
+    private _pos = getPos _x;
+    private _locationName = _x getVariable ["LocationName", ""];
+    if (_locationName isEqualTo "") then {
+        private _nearestLocation = [_pos] call EFUNC(common,getNearestLocationWithAvailableName);
+        _locationName = if (_nearestLocation isEqualTo locationNull) then {
+            random (999) toFixed 1
+        } else {
+            [_nearestLocation] call EFUNC(common,getLocationName);
+        };
+    };
+    _positions setVariable [_locationName, _pos];
+} forEach EGVAR(modules,killersStartPositions);
+
 _positions

--- a/addons/killers/functions/fnc_initStartPositions.sqf
+++ b/addons/killers/functions/fnc_initStartPositions.sqf
@@ -21,13 +21,21 @@ private _i = GVAR(startPositionsCount);
 private _positions = call CBA_fnc_createNamespace;
 
 while {_i > 0} do {
-    private _pos = [nil, false, false, true] call EFUNC(civilian,getRandomPos);
+    private _pos = [nil, false, false, true] call EFUNC(common,getRandomPos);
+    //diag_log format ["[AFSK] [KILLERS] [initStartPositions] Pos: %1", _pos];
     if (!(_pos isEqualTo [])) then {
-        private _nearestCity = [_pos, 1500] call EFUNC(civilian,getNearestCity);
-        if (_nearestCity isEqualTo objNull) exitWith {};
-        private _nearestLocation = [_pos, 1500] call EFUNC(common,getNearestLocation);
-        if (!(_positions getVariable [className _nearestLocation, []] isEqualTo [])) exitWith {};
-        _positions setVariable [className _nearestLocation, _pos];
+        private _nearestCity = [_pos, 1500] call EFUNC(common,getNearestCityLocation);
+        //diag_log format ["[AFSK] [KILLERS] [initStartPositions] City: %1", _nearestCity];
+        if (_nearestCity isEqualTo locationNull) exitWith {};
+        private _nearestLocation = [_pos, 1500] call EFUNC(common,getNearestLocationWithAvailableName);
+        //diag_log format ["[AFSK] [KILLERS] [initStartPositions] Location: %1", _nearestLocation];
+        if (_nearestLocation isEqualTo locationNull) exitWith {};
+        private _locationClassname = className _nearestLocation;
+        if (_locationClassname isEqualTo "") exitWith {};
+        //diag_log format ["[AFSK] [KILLERS] [initStartPositions] Location Classname: %1", _locationClassname];
+        if (!(_positions getVariable [_locationClassname, []] isEqualTo [])) exitWith {};
+        _positions setVariable [_locationClassname, _pos];
+        //diag_log format ["[AFSK] [KILLERS] [initStartPositions] Success"];
         _i = _i - 1;
     };
 };

--- a/addons/killers/functions/fnc_initStartPositions.sqf
+++ b/addons/killers/functions/fnc_initStartPositions.sqf
@@ -1,0 +1,35 @@
+#include "script_component.hpp"
+/*
+ * Author: 3Mydlo3
+ * Function initializes starting positions for killers (initial teleport destinations).
+ * Positions cannot be farther than 1500 m from any city and 1500 m from any location.
+ * Each location can have only one position assigned (to prevent stacking and avoid ambiguous teleports).
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * 0: location - position <CBA_NAMESPACE>
+ *
+ * Example:
+ * call afsk_killers_fnc_initStartPositions
+ *
+ * Public: No
+ */
+
+private _i = GVAR(startPositionsCount);
+private _positions = call CBA_fnc_createNamespace;
+
+while {_i > 0} do {
+    private _pos = [nil, false, false, true] call EFUNC(common,getRandomPos);
+    if (!(_pos isEqualTo [])) then {
+        private _nearestCity = [_pos, 1500] call EFUNC(civilian,getNearestCity);
+        if (_nearestCity isEqualTo objNull) exitWith {};
+        private _nearestLocation = [_pos, 1500] call EFUNC(common,getNearestLocation);
+        if (!(_positions getVariable [className _nearestLocation, []] isEqualTo [])) exitWith {};
+        _positions setVariable [className _nearestLocation, _pos];
+        _i = _i - 1;
+    };
+};
+
+_positions

--- a/addons/killers/functions/fnc_initStartPositions.sqf
+++ b/addons/killers/functions/fnc_initStartPositions.sqf
@@ -21,7 +21,7 @@ private _i = GVAR(startPositionsCount);
 private _positions = call CBA_fnc_createNamespace;
 
 while {_i > 0} do {
-    private _pos = [nil, false, false, true] call EFUNC(common,getRandomPos);
+    private _pos = [nil, false, false, true] call EFUNC(civilian,getRandomPos);
     if (!(_pos isEqualTo [])) then {
         private _nearestCity = [_pos, 1500] call EFUNC(civilian,getNearestCity);
         if (_nearestCity isEqualTo objNull) exitWith {};

--- a/addons/killers/functions/fnc_initStartPositions.sqf
+++ b/addons/killers/functions/fnc_initStartPositions.sqf
@@ -31,11 +31,11 @@ while {_i > 0} do {
         private _nearestLocation = [_pos, 1500] call EFUNC(common,getNearestLocationWithAvailableName);
         //diag_log format ["[AFSK] [KILLERS] [initStartPositions] Location: %1", _nearestLocation];
         if (_nearestLocation isEqualTo locationNull) exitWith {};
-        private _locationClassname = className _nearestLocation;
-        if (_locationClassname isEqualTo "") exitWith {};
-        //diag_log format ["[AFSK] [KILLERS] [initStartPositions] Location Classname: %1", _locationClassname];
-        if (!(_positions getVariable [_locationClassname, []] isEqualTo [])) exitWith {};
-        _positions setVariable [_locationClassname, _pos];
+        private _locationName = [_nearestLocation] call EFUNC(common,getLocationName);
+        if (_locationName isEqualTo "") exitWith {};
+        //diag_log format ["[AFSK] [KILLERS] [initStartPositions] Location Name: %1", _locationName];
+        if (!(_positions getVariable [_locationName, []] isEqualTo [])) exitWith {};
+        _positions setVariable [_locationName, _pos];
         //diag_log format ["[AFSK] [KILLERS] [initStartPositions] Success"];
         _i = _i - 1;
     };

--- a/addons/killers/initSettings.sqf
+++ b/addons/killers/initSettings.sqf
@@ -1,0 +1,10 @@
+#include "script_component.hpp"
+
+[
+    QGVAR(startPositionsCount),
+    "SLIDER",
+    [LSTRING(StartPositionsCount), LSTRING(StartPositionsCount_Description)],
+    LSTRING(DisplayName),
+    [-1, 30, 10, 0],
+    true
+] call CBA_fnc_addSetting;

--- a/addons/killers/initSettings.sqf
+++ b/addons/killers/initSettings.sqf
@@ -5,6 +5,6 @@
     "SLIDER",
     [LSTRING(StartPositionsCount), LSTRING(StartPositionsCount_Description)],
     LSTRING(DisplayName),
-    [-1, 30, 10, 0],
+    [-1, 30, 15, 0],
     true
 ] call CBA_fnc_addSetting;

--- a/addons/killers/stringtable.xml
+++ b/addons/killers/stringtable.xml
@@ -9,5 +9,13 @@
             <English>Killers</English>
             <Polish>Zabójcy</Polish>
         </Key>
+        <Key ID="STR_AFSK_Killers_StartPositionsCount">
+            <English>Start positions count</English>
+            <Polish>Liczba pozycji startowych</Polish>
+        </Key>
+        <Key ID="STR_AFSK_Killers_StartPositionsCount_Description">
+            <English>How many positions will be available to killers for teleportation on the beginning.</English>
+            <Polish>Ile pozycji do teleportacji na starcie będzie dostępnych dla zabójców.</Polish>
+        </Key>
     </Package>
 </Project>

--- a/addons/killers/stringtable.xml
+++ b/addons/killers/stringtable.xml
@@ -14,8 +14,8 @@
             <Polish>Liczba pozycji startowych</Polish>
         </Key>
         <Key ID="STR_AFSK_Killers_StartPositionsCount_Description">
-            <English>How many positions will be available to killers for teleportation on the beginning.</English>
-            <Polish>Ile pozycji do teleportacji na starcie będzie dostępnych dla zabójców.</Polish>
+            <English>How many positions will be available to killers for teleportation on the beginning. 0 or -1 to random [10, 20].</English>
+            <Polish>Ile pozycji do teleportacji na starcie będzie dostępnych dla zabójców. 0 lub -1 by wylosować z przedziału [10, 20]</Polish>
         </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- [x] Add starting positions count setting. We will ditch placing multiple start position modules in favor of automatic generation (to automate as much as possible)
- [x] Update common `FUNC(getLocationName)` support location classname param
- [x] Adjust `FUNC(createTeleport)` and `FUNC(createStartPositionMarker)` for new positions generation
- [x] `EFUNC(common,getLocationName)` fix error when location has no classname
- [x] Add `EFUNC(common,getRandomPos)`. Make `EFUNC(civilian,getRandomPos)` just call `EFUNC(common,getRandomPos)` for now. Will remove later.
- [x] `FUNC(getNearestLocationName)` support object/location param 
- [x] Add `EFUNC(getNearestLocationWithAvailableName)` which name speaks for itself
- [x] Rename markers array variable as there is no reason to keep "killers". Will do with all variables in the future
- [x] Add indexes to teleport positions names in case 2 locations have the same name
- [x] Add support for manually placed start position modules but they don't count to startPositionsCount