### PR TITLE
Add common equipment for killers and police

### DIFF
--- a/addons/equipment/XEH_PREP.hpp
+++ b/addons/equipment/XEH_PREP.hpp
@@ -2,3 +2,4 @@ PREP(initCommonEquipment);
 PREP(initEquipment);
 PREP(initKillersEquipment);
 PREP(initPoliceEquipment);
+PREP(readConfigToNamespace);

--- a/addons/equipment/XEH_PREP.hpp
+++ b/addons/equipment/XEH_PREP.hpp
@@ -1,3 +1,4 @@
+PREP(initCommonEquipment);
 PREP(initEquipment);
 PREP(initKillersEquipment);
 PREP(initPoliceEquipment);

--- a/addons/equipment/XEH_PREP.hpp
+++ b/addons/equipment/XEH_PREP.hpp
@@ -1,2 +1,3 @@
 PREP(initEquipment);
+PREP(initKillersEquipment);
 PREP(initPoliceEquipment);

--- a/addons/equipment/XEH_PREP.hpp
+++ b/addons/equipment/XEH_PREP.hpp
@@ -1,1 +1,2 @@
 PREP(initEquipment);
+PREP(initPoliceEquipment);

--- a/addons/equipment/XEH_preInit.sqf
+++ b/addons/equipment/XEH_preInit.sqf
@@ -5,7 +5,8 @@ ADDON = false;
 #include "initSettings.sqf"
 
 GVAR(equipmentPreset) = configNull;
-GVAR(commonEquipment) = [configNull];
+// Namespace containing common item name variables with value being loaded properties as namespace
+GVAR(commonEquipment) = call CBA_fnc_createNamespace;
 GVAR(policeEquipmentList) = [];
 GVAR(policeEquipmentScores) = call CBA_fnc_createNamespace;
 GVAR(killersStartEquipment) = [];

--- a/addons/equipment/XEH_preInit.sqf
+++ b/addons/equipment/XEH_preInit.sqf
@@ -10,6 +10,8 @@ GVAR(commonEquipment) = call CBA_fnc_createNamespace;
 GVAR(policeEquipmentList) = [];
 GVAR(policeEquipmentScores) = call CBA_fnc_createNamespace;
 GVAR(killersStartEquipment) = [];
+// Killers equipment (weapons and stuff) available in stashes
+GVAR(killersStashCommonEquipment) = [];
 GVAR(killersStashEquipment) = [];
 
 call FUNC(initEquipment);

--- a/addons/equipment/XEH_preInit.sqf
+++ b/addons/equipment/XEH_preInit.sqf
@@ -4,11 +4,15 @@ ADDON = false;
 
 #include "initSettings.sqf"
 
+// Selected equipment preset config
 GVAR(equipmentPreset) = configNull;
 // Namespace containing common item name variables with value being loaded properties as namespace
 GVAR(commonEquipment) = call CBA_fnc_createNamespace;
+// Unique police equipment list to prevent config duplicates (especially with different scores)
 GVAR(policeEquipmentList) = [];
+// Namespace using requiredScore as key and list of unlocked equipment as value
 GVAR(policeEquipmentScores) = call CBA_fnc_createNamespace;
+// Killers stuff available to choose from before action begins
 GVAR(killersStartEquipment) = [];
 // Killers equipment (weapons and stuff) available in stashes
 GVAR(killersStashCommonEquipment) = [];

--- a/addons/equipment/functions/fnc_initCommonEquipment.sqf
+++ b/addons/equipment/functions/fnc_initCommonEquipment.sqf
@@ -15,18 +15,6 @@
  * Public: No
  */
 
-params ["_equipmentConfig"];
+params ["_equipmentPresetConfig"];
 
-{
-    // Add item to list
-    private _itemConfig = _x;
-    private _itemNamespace = call CBA_fnc_createNamespace;
-    GVAR(commonEquipment) setVariable [configName _x, _itemNamespace];
-    // Get item properties
-    private _configProperties = configProperties [_x, "true", true];
-    private _foundProperties = SUPPORTED_PROPERTIES arrayIntersect _configProperties;
-    // Read config values for found properties
-    {
-        _itemNamespace setVariable [_x, getNumber (_itemConfig >> _x)];
-    } forEach _foundProperties;
-} forEach ("true" configClasses (_equipmentConfig >> "Common" >> "Equipment"));
+GVAR(commonEquipment) = [_equipmentPresetConfig >> "Common" >> "Equipment", GVAR(commonEquipment)] call FUNC(readConfigToNamespace);

--- a/addons/equipment/functions/fnc_initCommonEquipment.sqf
+++ b/addons/equipment/functions/fnc_initCommonEquipment.sqf
@@ -25,15 +25,8 @@ params ["_equipmentConfig"];
     // Get item properties
     private _configProperties = configProperties [_x, "true", true];
     private _foundProperties = SUPPORTED_PROPERTIES arrayIntersect _configProperties;
-    private _missingProperties = SUPPORTED_PROPERTIES - _foundProperties;
     // Read config values for found properties
     {
         _itemNamespace setVariable [_x, getNumber (_itemConfig >> _x)];
     } forEach _foundProperties;
-    // Set default values for missing properties
-    {
-        private _missingProperty = _x;
-        private _value = SUPPORTED_PROPERTIES_DEFAULTS select (SUPPORTED_PROPERTIES findIf {_x isEqualTo _missingProperty});
-        _itemNamespace setVariable [_x, _value];
-    } forEach _missingProperties;
 } forEach ("true" configClasses (_equipmentConfig >> "Common" >> "Equipment"));

--- a/addons/equipment/functions/fnc_initCommonEquipment.sqf
+++ b/addons/equipment/functions/fnc_initCommonEquipment.sqf
@@ -17,4 +17,15 @@
 
 params ["_equipmentPresetConfig"];
 
+#define ACE_MEDICAL_ITEMS "ACE_elasticBandage", "ACE_packingBandage", "ACE_fieldDressing", "ACE_quikclot", "ACE_morphine", "ACE_adenosine", "ACE_epinephrine", "ACE_bloodIV_250", "ACE_bloodIV_500", "ACE_bloodIV"
+
 GVAR(commonEquipment) = [_equipmentPresetConfig >> "Common" >> "Equipment", GVAR(commonEquipment)] call FUNC(readConfigToNamespace);
+
+if (EGVAR(common,ACE_Loaded)) then {
+    // Check if any ACE items were already added, if so, skip autoadd
+    if ((allVariables GVAR(commonEquipment) findIf {["ACE", _x, false] call BIS_fnc_inString}) isEqualTo -1) then {
+        {
+            GVAR(commonEquipment) setVariable [_x, call CBA_fnc_createNamespace];
+        } forEach [ACE_MEDICAL_ITEMS, "ACE_Flashlight_XL50", "ACE_MapTools"];
+    };
+};

--- a/addons/equipment/functions/fnc_initCommonEquipment.sqf
+++ b/addons/equipment/functions/fnc_initCommonEquipment.sqf
@@ -1,0 +1,39 @@
+#include "script_component.hpp"
+/*
+ * Author: 3Mydlo3
+ * Function prepares common equipment namespace from given config.
+ *
+ * Arguments:
+ * 0: Eqipment config <CONFIG>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * None
+ *
+ * Public: No
+ */
+
+params ["_equipmentConfig"];
+
+{
+    // Add item to list
+    private _itemConfig = _x;
+    private _itemNamespace = call CBA_fnc_createNamespace;
+    GVAR(commonEquipment) setVariable [configName _x, _itemNamespace];
+    // Get item properties
+    private _configProperties = configProperties [_x, "true", true];
+    private _foundProperties = SUPPORTED_PROPERTIES arrayIntersect _configProperties;
+    private _missingProperties = SUPPORTED_PROPERTIES - _foundProperties;
+    // Read config values for found properties
+    {
+        _itemNamespace setVariable [_x, getNumber (_itemConfig >> _x)];
+    } forEach _foundProperties;
+    // Set default values for missing properties
+    {
+        private _missingProperty = _x;
+        private _value = SUPPORTED_PROPERTIES_DEFAULTS select (SUPPORTED_PROPERTIES findIf {_x isEqualTo _missingProperty});
+        _itemNamespace setVariable [_x, _value];
+    } forEach _missingProperties;
+} forEach ("true" configClasses (_equipmentConfig >> "Common" >> "Equipment"));

--- a/addons/equipment/functions/fnc_initEquipment.sqf
+++ b/addons/equipment/functions/fnc_initEquipment.sqf
@@ -44,7 +44,6 @@ if (GVAR(equipmentPresetCustom) && {isClass _missionEquipmentConfig}) then {
 
 GVAR(equipmentPreset) = _equipmentConfig;
 GVAR(commonEquipment) = "true" configClasses (_equipmentConfig >> "Common" >> "Equipment");
-GVAR(killersEquipment) = "true" configClasses (_equipmentConfig >> "Killers" >> "Equipment");
 
 [_equipmentConfig] call FUNC(initPoliceEquipment);
 [_equipmentConfig] call FUNC(initKillersEquipment);

--- a/addons/equipment/functions/fnc_initEquipment.sqf
+++ b/addons/equipment/functions/fnc_initEquipment.sqf
@@ -47,14 +47,4 @@ GVAR(commonEquipment) = "true" configClasses (_equipmentConfig >> "Common" >> "E
 GVAR(killersEquipment) = "true" configClasses (_equipmentConfig >> "Killers" >> "Equipment");
 
 [_equipmentConfig] call FUNC(initPoliceEquipment);
-
-{
-    private _availableOnStart = getNumber (_x >> "availableOnStart");
-    private _availableInStash = getNumber (_x >> "availableInStash");
-    if (_availableOnStart isEqualTo 1) then {
-        GVAR(killersStartEquipment) pushBackUnique (configName _x);
-    };
-    if (_availableInStash isEqualTo 1) then {
-        GVAR(killersStashEquipment) pushBackUnique (configName _x);
-    };
-} forEach GVAR(killersEquipment);
+[_equipmentConfig] call FUNC(initKillersEquipment);

--- a/addons/equipment/functions/fnc_initEquipment.sqf
+++ b/addons/equipment/functions/fnc_initEquipment.sqf
@@ -15,34 +15,34 @@
  * Public: No
  */
 
-private _equipmentConfig = (configFile >> "CfgSerialKillers" >> "Equipment_Presets");
+private _equipmentPresetConfig = (configFile >> "CfgSerialKillers" >> "Equipment_Presets");
 private _missionEquipmentConfig = (missionConfigFile >> "CfgSerialKillers" >> "Equipment_Presets");
 
 if (GVAR(equipmentPresetCustom) && {isClass _missionEquipmentConfig}) then {
-    _equipmentConfig = (_missionEquipmentConfig >> "Custom");
+    _equipmentPresetConfig = (_missionEquipmentConfig >> "Custom");
 } else {
-    _equipmentConfig = switch (GVAR(equipmentPreset)) do {
+    _equipmentPresetConfig = switch (GVAR(equipmentPreset)) do {
         // Vanilla config
-        case 1: {_equipmentConfig >> "Vanilla"};
+        case 1: {_equipmentPresetConfig >> "Vanilla"};
         // RHS config
-        case 2: {_equipmentConfig >> "RHS"};
+        case 2: {_equipmentPresetConfig >> "RHS"};
         // CUP config
-        case 3: {_equipmentConfig >> "CUP"};
+        case 3: {_equipmentPresetConfig >> "CUP"};
         // CUP & RHS config
-        case 4: {_equipmentConfig >> "CUP_RHS"};
+        case 4: {_equipmentPresetConfig >> "CUP_RHS"};
         // Automatic config selection based on loaded addons
         default {
             if (EGVAR(common,RHS_Loaded) && {EGVAR(common,CUP_Loaded)}) exitWith {
-                _equipmentConfig >> "CUP_RHS"
+                _equipmentPresetConfig >> "CUP_RHS"
             };
-            if (EGVAR(common,RHS_Loaded)) exitWith {_equipmentConfig >> "RHS"};
-            if (EGVAR(common,CUP_Loaded)) exitWith {_equipmentConfig >> "CUP"};
-            _equipmentConfig >> "Vanilla"
+            if (EGVAR(common,RHS_Loaded)) exitWith {_equipmentPresetConfig >> "RHS"};
+            if (EGVAR(common,CUP_Loaded)) exitWith {_equipmentPresetConfig >> "CUP"};
+            _equipmentPresetConfig >> "Vanilla"
         };
     };
 };
 
-GVAR(equipmentPreset) = _equipmentConfig;
+GVAR(equipmentPreset) = _equipmentPresetConfig;
 
 [GVAR(equipmentPreset)] call FUNC(initCommonEquipment);
 [GVAR(equipmentPreset)] call FUNC(initPoliceEquipment);

--- a/addons/equipment/functions/fnc_initEquipment.sqf
+++ b/addons/equipment/functions/fnc_initEquipment.sqf
@@ -46,38 +46,7 @@ GVAR(equipmentPreset) = _equipmentConfig;
 GVAR(commonEquipment) = "true" configClasses (_equipmentConfig >> "Common" >> "Equipment");
 GVAR(killersEquipment) = "true" configClasses (_equipmentConfig >> "Killers" >> "Equipment");
 
-private _policeEquipment = [];
-{
-    private _itemRequiredScore = getNumber (_x >> "requiredScore");
-    _policeEquipment pushBack [_itemRequiredScore, _x];
-} forEach ("true" configClasses (_equipmentConfig >> "Police" >> "Equipment"));
-_policeEquipment sort true;
-
-{
-    private _itemRequiredScore = _x select 0;
-    private _item = _x select 1;
-    private _itemClassName = configName _item;
-    private _requiredScoreList = GVAR(policeEquipmentScores) getVariable [str _itemRequiredScore, []];
-    if (_requiredScoreList isEqualTo []) then {
-        GVAR(policeEquipmentScores) setVariable [str _itemRequiredScore, _requiredScoreList];
-    };
-    if (!((GVAR(policeEquipmentList) pushBackUnique _itemClassName) isEqualTo -1)) then {
-        _requiredScoreList pushBack _itemClassName;
-    };
-    // If item is weapon, load it's magazines
-    private _weaponConfig = (configFile >> "CfgWeapons" >> _itemClassName);
-    if (isClass _weaponConfig) then {
-        // Check if magazines for this weapon are disabled (must be "false")
-        private _loadMagazines = getText (_item >> "loadMagazines");
-        if (_loadMagazines isEqualTo "false") exitwith {};
-        private _magazines = [_itemClassName, true] call CBA_fnc_compatibleMagazines;
-        {
-            if (!((GVAR(policeEquipmentList) pushBackUnique _x) isEqualTo -1)) then {
-                _requiredScoreList pushBack _x;
-            };
-        } forEach _magazines;
-    };
-} forEach _policeEquipment;
+[_equipmentConfig] call FUNC(initPoliceEquipment);
 
 {
     private _availableOnStart = getNumber (_x >> "availableOnStart");

--- a/addons/equipment/functions/fnc_initEquipment.sqf
+++ b/addons/equipment/functions/fnc_initEquipment.sqf
@@ -43,7 +43,7 @@ if (GVAR(equipmentPresetCustom) && {isClass _missionEquipmentConfig}) then {
 };
 
 GVAR(equipmentPreset) = _equipmentConfig;
-GVAR(commonEquipment) = "true" configClasses (_equipmentConfig >> "Common" >> "Equipment");
 
-[_equipmentConfig] call FUNC(initPoliceEquipment);
-[_equipmentConfig] call FUNC(initKillersEquipment);
+[GVAR(equipmentPreset)] call FUNC(initCommonEquipment);
+[GVAR(equipmentPreset)] call FUNC(initPoliceEquipment);
+[GVAR(equipmentPreset)] call FUNC(initKillersEquipment);

--- a/addons/equipment/functions/fnc_initKillersEquipment.sqf
+++ b/addons/equipment/functions/fnc_initKillersEquipment.sqf
@@ -19,6 +19,7 @@ params ["_equipmentConfig"];
 
 private _killersEquipment = "true" configClasses (_equipmentConfig >> "Killers" >> "Equipment");
 
+// Add killers equipment
 {
     private _availableOnStart = getNumber (_x >> "availableOnStart");
     private _availableInStash = getNumber (_x >> "availableInStash");
@@ -29,3 +30,15 @@ private _killersEquipment = "true" configClasses (_equipmentConfig >> "Killers" 
         GVAR(killersStashEquipment) pushBackUnique (configName _x);
     };
 } forEach _killersEquipment;
+
+// Add common equipment
+{
+    private _availableOnStart = _x getVariable ["availableOnStart", 1];
+    private _availableInStash = _x getVariable ["availableInStash", 1];
+    if (_availableOnStart isEqualTo 1) then {
+        GVAR(killersStartEquipment) pushBackUnique (configName _x);
+    };
+    if (_availableInStash isEqualTo 1) then {
+        GVAR(killersStashCommonEquipment) pushBackUnique (configName _x);
+    };
+} forEach (allVariables GVAR(commonEquipment));

--- a/addons/equipment/functions/fnc_initKillersEquipment.sqf
+++ b/addons/equipment/functions/fnc_initKillersEquipment.sqf
@@ -17,19 +17,21 @@
 
 params ["_equipmentPresetConfig"];
 
-private _killersEquipment = "true" configClasses (_equipmentPresetConfig >> "Killers" >> "Equipment");
+private _killersEquipment = [_equipmentPresetConfig >> "Killers" >> "Equipment"] call FUNC(readConfigToNamespace);
 
 // Add killers equipment
 {
-    private _availableOnStart = getNumber (_x >> "availableOnStart");
-    private _availableInStash = getNumber (_x >> "availableInStash");
+    private _itemClassname = _x;
+    private _item = _killersEquipment getVariable _itemClassname;
+    private _availableOnStart = _item getVariable ["availableOnStart", 1];
+    private _availableInStash = _item getVariable ["availableInStash", 1];
     if (_availableOnStart isEqualTo 1) then {
-        GVAR(killersStartEquipment) pushBackUnique (configName _x);
+        GVAR(killersStartEquipment) pushBackUnique (_itemClassname);
     };
     if (_availableInStash isEqualTo 1) then {
-        GVAR(killersStashEquipment) pushBackUnique (configName _x);
+        GVAR(killersStashEquipment) pushBackUnique (_itemClassname);
     };
-} forEach _killersEquipment;
+} forEach (allVariables _killersEquipment);
 
 // Add common equipment
 {

--- a/addons/equipment/functions/fnc_initKillersEquipment.sqf
+++ b/addons/equipment/functions/fnc_initKillersEquipment.sqf
@@ -33,12 +33,14 @@ private _killersEquipment = "true" configClasses (_equipmentConfig >> "Killers" 
 
 // Add common equipment
 {
-    private _availableOnStart = _x getVariable ["availableOnStart", 1];
-    private _availableInStash = _x getVariable ["availableInStash", 1];
+    private _itemClassname = _x;
+    private _item = GVAR(commonEquipment) getVariable _itemClassname;
+    private _availableOnStart = _item getVariable ["availableOnStart", 1];
+    private _availableInStash = _item getVariable ["availableInStash", 1];
     if (_availableOnStart isEqualTo 1) then {
-        GVAR(killersStartEquipment) pushBackUnique (configName _x);
+        GVAR(killersStartEquipment) pushBackUnique (_itemClassname);
     };
     if (_availableInStash isEqualTo 1) then {
-        GVAR(killersStashCommonEquipment) pushBackUnique (configName _x);
+        GVAR(killersStashCommonEquipment) pushBackUnique (_itemClassname);
     };
 } forEach (allVariables GVAR(commonEquipment));

--- a/addons/equipment/functions/fnc_initKillersEquipment.sqf
+++ b/addons/equipment/functions/fnc_initKillersEquipment.sqf
@@ -17,6 +17,8 @@
 
 params ["_equipmentConfig"];
 
+private _killersEquipment = "true" configClasses (_equipmentConfig >> "Killers" >> "Equipment");
+
 {
     private _availableOnStart = getNumber (_x >> "availableOnStart");
     private _availableInStash = getNumber (_x >> "availableInStash");
@@ -26,4 +28,4 @@ params ["_equipmentConfig"];
     if (_availableInStash isEqualTo 1) then {
         GVAR(killersStashEquipment) pushBackUnique (configName _x);
     };
-} forEach GVAR(killersEquipment);
+} forEach _killersEquipment;

--- a/addons/equipment/functions/fnc_initKillersEquipment.sqf
+++ b/addons/equipment/functions/fnc_initKillersEquipment.sqf
@@ -1,0 +1,29 @@
+#include "script_component.hpp"
+/*
+ * Author: 3Mydlo3
+ * Function prepares killers equipment from given config.
+ *
+ * Arguments:
+ * 0: Eqipment config <CONFIG>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * None
+ *
+ * Public: No
+ */
+
+params ["_equipmentConfig"];
+
+{
+    private _availableOnStart = getNumber (_x >> "availableOnStart");
+    private _availableInStash = getNumber (_x >> "availableInStash");
+    if (_availableOnStart isEqualTo 1) then {
+        GVAR(killersStartEquipment) pushBackUnique (configName _x);
+    };
+    if (_availableInStash isEqualTo 1) then {
+        GVAR(killersStashEquipment) pushBackUnique (configName _x);
+    };
+} forEach GVAR(killersEquipment);

--- a/addons/equipment/functions/fnc_initKillersEquipment.sqf
+++ b/addons/equipment/functions/fnc_initKillersEquipment.sqf
@@ -15,9 +15,9 @@
  * Public: No
  */
 
-params ["_equipmentConfig"];
+params ["_equipmentPresetConfig"];
 
-private _killersEquipment = "true" configClasses (_equipmentConfig >> "Killers" >> "Equipment");
+private _killersEquipment = "true" configClasses (_equipmentPresetConfig >> "Killers" >> "Equipment");
 
 // Add killers equipment
 {

--- a/addons/equipment/functions/fnc_initPoliceEquipment.sqf
+++ b/addons/equipment/functions/fnc_initPoliceEquipment.sqf
@@ -23,6 +23,13 @@ private _policeEquipment = [];
     private _itemRequiredScore = getNumber (_x >> "requiredScore");
     _policeEquipment pushBack [_itemRequiredScore, _x];
 } forEach ("true" configClasses (_equipmentConfig >> "Police" >> "Equipment"));
+// Add common equipment
+{
+    private _itemClassname = _x;
+    private _item = GVAR(commonEquipment) getVariable _itemClassname;
+    private _itemRequiredScore = _item getVariable ["requiredScore", 0];
+    _policeEquipment pushBack [_itemRequiredScore, _itemClassname];
+} forEach (allVariables GVAR(commonEquipment));
 _policeEquipment sort true;
 
 {

--- a/addons/equipment/functions/fnc_initPoliceEquipment.sqf
+++ b/addons/equipment/functions/fnc_initPoliceEquipment.sqf
@@ -15,14 +15,14 @@
  * Public: No
  */
 
-params ["_equipmentConfig"];
+params ["_equipmentPresetConfig"];
 
 // Get all defined equipment and sort by required score from lowest to highest
 private _policeEquipment = [];
 {
     private _itemRequiredScore = getNumber (_x >> "requiredScore");
     _policeEquipment pushBack [_itemRequiredScore, _x];
-} forEach ("true" configClasses (_equipmentConfig >> "Police" >> "Equipment"));
+} forEach ("true" configClasses (_equipmentPresetConfig >> "Police" >> "Equipment"));
 // Add common equipment
 {
     private _itemClassname = _x;

--- a/addons/equipment/functions/fnc_initPoliceEquipment.sqf
+++ b/addons/equipment/functions/fnc_initPoliceEquipment.sqf
@@ -1,0 +1,52 @@
+#include "script_component.hpp"
+/*
+ * Author: 3Mydlo3
+ * Function prepares police equipment from given config.
+ *
+ * Arguments:
+ * 0: Eqipment config <CONFIG>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * None
+ *
+ * Public: No
+ */
+
+params ["_equipmentConfig"];
+
+// Get all defined equipment and sort by required score from lowest to highest
+private _policeEquipment = [];
+{
+    private _itemRequiredScore = getNumber (_x >> "requiredScore");
+    _policeEquipment pushBack [_itemRequiredScore, _x];
+} forEach ("true" configClasses (_equipmentConfig >> "Police" >> "Equipment"));
+_policeEquipment sort true;
+
+{
+    private _itemRequiredScore = _x select 0;
+    private _item = _x select 1;
+    private _itemClassName = configName _item;
+    private _requiredScoreList = GVAR(policeEquipmentScores) getVariable [str _itemRequiredScore, []];
+    if (_requiredScoreList isEqualTo []) then {
+        GVAR(policeEquipmentScores) setVariable [str _itemRequiredScore, _requiredScoreList];
+    };
+    if (!((GVAR(policeEquipmentList) pushBackUnique _itemClassName) isEqualTo -1)) then {
+        _requiredScoreList pushBack _itemClassName;
+    };
+    // If item is weapon, load it's magazines
+    private _weaponConfig = (configFile >> "CfgWeapons" >> _itemClassName);
+    if (isClass _weaponConfig) then {
+        // Check if magazines for this weapon are disabled (must be "false")
+        private _loadMagazines = getText (_item >> "loadMagazines");
+        if (_loadMagazines isEqualTo "false") exitwith {};
+        private _magazines = [_itemClassName, true] call CBA_fnc_compatibleMagazines;
+        {
+            if (!((GVAR(policeEquipmentList) pushBackUnique _x) isEqualTo -1)) then {
+                _requiredScoreList pushBack _x;
+            };
+        } forEach _magazines;
+    };
+} forEach _policeEquipment;

--- a/addons/equipment/functions/fnc_readConfigToNamespace.sqf
+++ b/addons/equipment/functions/fnc_readConfigToNamespace.sqf
@@ -1,0 +1,36 @@
+#include "script_component.hpp"
+/*
+ * Author: 3Mydlo3
+ * Function reads all properties of all subclasses (1 lvl) of given config
+ * and saves to namespace for easier access
+ * (and ability to easily create default value if property doesn't exits)
+ *
+ * Arguments:
+ * 0: Config to read from <CONFIG>
+ * 1: Namespace to save data to <CBA_NAMESPACE>
+ *
+ * Return Value:
+ * 0: Filled/created namespace <CBA_NAMESPACE>
+ *
+ * Example:
+ * None
+ *
+ * Public: No
+ */
+
+params ["_config", ["_namespace", call CBA_fnc_createNamespace]];
+
+{
+    // Add item to list
+    private _itemConfig = _x;
+    private _itemNamespace = call CBA_fnc_createNamespace;
+    _namespace setVariable [configName _x, _itemNamespace];
+    // Get item properties
+    private _foundProperties = SUPPORTED_PROPERTIES arrayIntersect (configProperties [_x, "true", true]);
+    // Read config values for found properties
+    {
+        _itemNamespace setVariable [_x, getNumber (_itemConfig >> _x)];
+    } forEach _foundProperties;
+} forEach ("true" configClasses _config);
+
+_namespace

--- a/addons/equipment/functions/fnc_readConfigToNamespace.sqf
+++ b/addons/equipment/functions/fnc_readConfigToNamespace.sqf
@@ -22,21 +22,19 @@ params ["_config", ["_namespace", call CBA_fnc_createNamespace]];
 
 {
     // Add item to list
-    private _itemConfig = _x;
     private _itemNamespace = call CBA_fnc_createNamespace;
     _namespace setVariable [configName _x, _itemNamespace];
     // Get item properties
-    private _foundProperties = SUPPORTED_PROPERTIES arrayIntersect (configProperties [_x, "true", true]);
     // Read config values for found properties
     {
         private _value = switch (true) do {
-            case (isNumber _x): {getNumber (_itemConfig >> _x)};
-            case (isText _x): {getText (_itemConfig >> _x)};
-            case (isArray _x): {getArray (_itemConfig >> _x)};
+            case (isNumber _x): {getNumber _x};
+            case (isText _x): {getText _x};
+            case (isArray _x): {getArray _x};
             default {configNull};
         };
-        _itemNamespace setVariable [_x, _value];
-    } forEach _foundProperties;
+        _itemNamespace setVariable [configName _x, _value];
+    } forEach (configProperties [_x, "true", true]);
 } forEach ("true" configClasses _config);
 
 _namespace

--- a/addons/equipment/functions/fnc_readConfigToNamespace.sqf
+++ b/addons/equipment/functions/fnc_readConfigToNamespace.sqf
@@ -29,7 +29,13 @@ params ["_config", ["_namespace", call CBA_fnc_createNamespace]];
     private _foundProperties = SUPPORTED_PROPERTIES arrayIntersect (configProperties [_x, "true", true]);
     // Read config values for found properties
     {
-        _itemNamespace setVariable [_x, getNumber (_itemConfig >> _x)];
+        private _value = switch (true) do {
+            case (isNumber _x): {getNumber (_itemConfig >> _x)};
+            case (isText _x): {getText (_itemConfig >> _x)};
+            case (isArray _x): {getArray (_itemConfig >> _x)};
+            default {configNull};
+        };
+        _itemNamespace setVariable [_x, _value];
     } forEach _foundProperties;
 } forEach ("true" configClasses _config);
 

--- a/addons/equipment/script_component.hpp
+++ b/addons/equipment/script_component.hpp
@@ -12,3 +12,6 @@
 #endif
 
 #include "\z\afsk\addons\main\script_macros.hpp"
+
+#define SUPPORTED_PROPERTIES ["requiredScore", "availableInStash", "availableOnStart"]
+#define SUPPORTED_PROPERTIES_DEFAULTS [0, 1, 1]

--- a/addons/equipment/script_component.hpp
+++ b/addons/equipment/script_component.hpp
@@ -12,6 +12,3 @@
 #endif
 
 #include "\z\afsk\addons\main\script_macros.hpp"
-
-#define SUPPORTED_PROPERTIES ["requiredScore", "loadMagazines", "availableInStash", "availableOnStart"]
-#define SUPPORTED_PROPERTIES_DEFAULTS [0, true, 1, 1]

--- a/addons/equipment/script_component.hpp
+++ b/addons/equipment/script_component.hpp
@@ -13,5 +13,5 @@
 
 #include "\z\afsk\addons\main\script_macros.hpp"
 
-#define SUPPORTED_PROPERTIES ["requiredScore", "availableInStash", "availableOnStart"]
-#define SUPPORTED_PROPERTIES_DEFAULTS [0, 1, 1]
+#define SUPPORTED_PROPERTIES ["requiredScore", "loadMagazines", "availableInStash", "availableOnStart"]
+#define SUPPORTED_PROPERTIES_DEFAULTS [0, true, 1, 1]

--- a/addons/killers/XEH_PREP.hpp
+++ b/addons/killers/XEH_PREP.hpp
@@ -1,3 +1,4 @@
+PREP(addItemToStash);
 PREP(createStartPositionMarker);
 PREP(createTeleport);
 PREP(deleteStartPositionsMarkers);

--- a/addons/killers/functions/fnc_addItemToStash.sqf
+++ b/addons/killers/functions/fnc_addItemToStash.sqf
@@ -1,0 +1,31 @@
+#include "script_component.hpp"
+/*
+ * Author: 3Mydlo3
+ * Function add given item in given amount to given stash.
+ *
+ * Arguments:
+ * 0: Box to add items to <OBJECT>
+ * 1: Item classname <STRING>
+ * 2: Item quantity <NUMBER>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * None
+ *
+ * Public: No
+ */
+
+params ["_box", "_itemClassname", ["_itemQuantity", 1]];
+
+for "_z" from 0 to _itemQuantity step 1 do {
+    _box addItemCargoGlobal _itemClassname;
+    private _compatibleMagazines = [_itemClassname] call CBA_fnc_compatibleMagazines;
+    if (!(_compatibleMagazines isEqualTo [])) then {
+        private _magazinesQuantity = ceil (random 4);
+        for "_v" from 0 to _magazinesQuantity step 1 do {
+            _box addItemCargoGlobal (selectRandom _compatibleMagazines);
+        };
+    };
+};

--- a/addons/killers/functions/fnc_fillKillersStash.sqf
+++ b/addons/killers/functions/fnc_fillKillersStash.sqf
@@ -23,14 +23,5 @@ private _itemsCount = ceil (random 3) + floor (_stashAvailableItemsCount/10);
 for "_y" from 0 to _itemsCount step 1 do {
     private _newItem = selectRandom EGVAR(equipment,killersStashEquipment);
     private _itemQuantity = ceil (random 2);
-    for "_z" from 0 to _itemQuantity step 1 do {
-        _box addItemCargoGlobal _newItem;
-        private _compatibleMagazines = [_newItem] call CBA_fnc_compatibleMagazines;
-        if (!(_compatibleMagazines isEqualTo [])) then {
-            private _magazinesQuantity = ceil (random 4);
-            for "_v" from 0 to _magazinesQuantity step 1 do {
-                _box addItemCargoGlobal (selectRandom _compatibleMagazines);
-            };
-        };
-    };
+    [_box, _newItem, _itemQuantity] call FUNC(addItemToStash);
 };

--- a/addons/killers/functions/fnc_fillKillersStash.sqf
+++ b/addons/killers/functions/fnc_fillKillersStash.sqf
@@ -17,6 +17,7 @@
 
 params ["_box"];
 
+// Add regular items
 private _stashAvailableItemsCount = count EGVAR(equipment,killersStashEquipment);
 private _itemsCount = ceil (random 3) + floor (_stashAvailableItemsCount/10);
 
@@ -24,4 +25,14 @@ for "_y" from 0 to _itemsCount step 1 do {
     private _newItem = selectRandom EGVAR(equipment,killersStashEquipment);
     private _itemQuantity = ceil (random 2);
     [_box, _newItem, _itemQuantity] call FUNC(addItemToStash);
+};
+
+// Add common items independently
+private _stashAvailableCommonItemsCount = count EGVAR(equipment,killersStashCommonEquipment);
+private _commonItemsCount = ceil (random 3) + floor (_stashAvailableCommonItemsCount/10);
+
+for "_y" from 0 to _itemsCount step 1 do {
+    private _newCommonItem = selectRandom EGVAR(equipment,killersStashCommonEquipment);
+    private _itemQuantity = ceil (random 2);
+    [_box, _newCommonItem, _itemQuantity] call FUNC(addItemToStash);
 };


### PR DESCRIPTION
**When merged this pull request will:**
- [x] Add common equipment for killers and police
- [x] Move police equipment init to separate function
- [x] Move killers equipment init to separate function
- [x] Add `FUNC(initCommonEquipment)`
- [x] Remove unnecessary `GVAR(killersEquipment)`
- [x] Create `GVAR(commonEquipment)` namespace containing common item classname variables with value being loaded properties as namespace (`GVAR(commonEquipment)` -> variable `"ItemGPS"` -> config properties as strings `"requiredScore"` which will be empty if not defined.
- [x] Prepare similar GVARs for police and killers equipment for easy access
- [x] Add basic ACE equipment if ACE is loaded and no ACE equipment was defined in common config
~~- [ ] Move preparation of `GVAR(policeEquipmentScores)` to `police` component~~