### PR TITLE
Add police vehicles

### DIFF
--- a/addons/civilian/functions/fnc_createVehicle.sqf
+++ b/addons/civilian/functions/fnc_createVehicle.sqf
@@ -18,7 +18,7 @@
  * Public: No
  */
 
-params ["_vehicleClassname", "_position", ["_dir", random 360], ["_emptyCargo", true], ["_enableRandomization", true]];
+params ["_vehicleClassname", "_position", ["_dir", random 360], ["_emptyCargo", true], ["_enableRandomization", true], ["_forcePosition", false]];
 
 if (_vehicleClassname isEqualType configNull) then {
     _vehicleClassname = configName _vehicleClassname;
@@ -28,7 +28,8 @@ if (_position isEqualType objNull) then {
     _position = getPos _position;
 };
 
-private _vehicle = createVehicle [_vehicleClassname, _position, [], 0, "NONE"];
+private _mode = if (_forcePosition) then {"CAN_COLLIDE"} else {"NONE"};
+private _vehicle = createVehicle [_vehicleClassname, _position, [], 0, _mode];
 _vehicle setDir _dir;
 // Disable randomization and use own function to set texture on vehicle globally (so everyone can see the same color!)
 _vehicle setVariable ["BIS_enableRandomization", false];

--- a/addons/civilian/functions/fnc_createVehicle.sqf
+++ b/addons/civilian/functions/fnc_createVehicle.sqf
@@ -7,6 +7,7 @@
  * 0: Vehicle classname or config <STRING/CONFIG>
  * 1: Position <POSITION>
  * 2: Remove cargo <BOOL>
+ * 3: Enable texture randomization <BOOL>
  *
  * Return Value:
  * 0: Created vehicle <OBJECT>
@@ -17,7 +18,7 @@
  * Public: No
  */
 
-params ["_vehicleClassname", "_position", ["_dir", random 360], ["_emptyCargo", true]];
+params ["_vehicleClassname", "_position", ["_dir", random 360], ["_emptyCargo", true], ["_enableRandomization", true]];
 
 if (_vehicleClassname isEqualType configNull) then {
     _vehicleClassname = configName _vehicleClassname;
@@ -27,6 +28,9 @@ private _vehicle = createVehicle [_vehicleClassname, _position, [], 0, "NONE"];
 _vehicle setDir _dir;
 // Disable randomization and use own function to set texture on vehicle globally (so everyone can see the same color!)
 _vehicle setVariable ["BIS_enableRandomization", false];
+if (_enableRandomization) then {
+    [_vehicle] call EFUNC(common,setVehicleRandomTexture);
+};
 [_vehicle] call EFUNC(common,setVehicleRandomTexture);
 
 if (_emptyCargo) then {

--- a/addons/civilian/functions/fnc_createVehicle.sqf
+++ b/addons/civilian/functions/fnc_createVehicle.sqf
@@ -35,7 +35,6 @@ _vehicle setVariable ["BIS_enableRandomization", false];
 if (_enableRandomization) then {
     [_vehicle] call EFUNC(common,setVehicleRandomTexture);
 };
-[_vehicle] call EFUNC(common,setVehicleRandomTexture);
 
 if (_emptyCargo) then {
     clearItemCargoGlobal _vehicle;

--- a/addons/civilian/functions/fnc_createVehicle.sqf
+++ b/addons/civilian/functions/fnc_createVehicle.sqf
@@ -24,6 +24,10 @@ if (_vehicleClassname isEqualType configNull) then {
     _vehicleClassname = configName _vehicleClassname;
 };
 
+if (_position isEqualType objNull) then {
+    _position = getPos _position;
+};
+
 private _vehicle = createVehicle [_vehicleClassname, _position, [], 0, "NONE"];
 _vehicle setDir _dir;
 // Disable randomization and use own function to set texture on vehicle globally (so everyone can see the same color!)

--- a/addons/equipment/CfgSerialKillers.hpp
+++ b/addons/equipment/CfgSerialKillers.hpp
@@ -153,6 +153,18 @@ class CfgSerialKillers {
                     class H_HelmetB_light_black: V_PlateCarrier2_blk {};
                     class H_PASGT_basic_blue_F: V_PlateCarrierSpec_blk {};
                 };
+
+                class Vehicles {
+                    /* Vehicles */
+                    class B_GEN_Offroad_01_gen_F {};
+                    class B_G_Offroad_01_armed_F {
+                        requiredScore = 20;
+                    };
+                    /* Helicopters */
+                    class I_Heli_light_03_unarmed_F {
+                        requiredScore = 15;
+                    };
+                };
             };
         };
     };

--- a/addons/equipment/XEH_PREP.hpp
+++ b/addons/equipment/XEH_PREP.hpp
@@ -2,4 +2,5 @@ PREP(initCommonEquipment);
 PREP(initEquipment);
 PREP(initKillersEquipment);
 PREP(initPoliceEquipment);
+PREP(initPoliceVehicles);
 PREP(readConfigToNamespace);

--- a/addons/equipment/XEH_PREP.hpp
+++ b/addons/equipment/XEH_PREP.hpp
@@ -1,3 +1,4 @@
+PREP(getRequiredScoreForItem);
 PREP(initCommonEquipment);
 PREP(initEquipment);
 PREP(initKillersEquipment);

--- a/addons/equipment/XEH_preInit.sqf
+++ b/addons/equipment/XEH_preInit.sqf
@@ -8,10 +8,12 @@ ADDON = false;
 GVAR(equipmentPreset) = configNull;
 // Namespace containing common item name variables with value being loaded properties as namespace
 GVAR(commonEquipment) = call CBA_fnc_createNamespace;
-// Unique police equipment list to prevent config duplicates (especially with different scores)
+// Unique police equipment and vehicles lists to prevent config duplicates (especially with different scores)
 GVAR(policeEquipmentList) = [];
-// Namespace using requiredScore as key and list of unlocked equipment as value
+GVAR(policeVehiclesList) = [];
+// Namespace using requiredScore as key and list of unlocked equipment/vehicles as value
 GVAR(policeEquipmentScores) = call CBA_fnc_createNamespace;
+GVAR(policeVehiclesScores) = call CBA_fnc_createNamespace;
 // Killers stuff available to choose from before action begins
 GVAR(killersStartEquipment) = [];
 // Killers equipment (weapons and stuff) available in stashes

--- a/addons/equipment/functions/fnc_getRequiredScoreForItem.sqf
+++ b/addons/equipment/functions/fnc_getRequiredScoreForItem.sqf
@@ -1,0 +1,48 @@
+#include "script_component.hpp"
+/*
+ * Author: 3Mydlo3
+ * Function returns required score for given item/vehicle
+ *
+ * Arguments:
+ * 0: Item/Vehicle/Classname <OBJECT/STRING>
+ *
+ * Return Value:
+ * 0: Required score <NUMBER>
+ *
+ * Example:
+ * [vehicle player] call afsk_equipment_fnc_getRequiredScoreForItem
+ *
+ * Public: No
+ */
+
+params ["_item"];
+
+// Handling for objects
+if (_item isEqualType objNull) then {
+    _item = typeOf _item;
+};
+
+// No classname provided
+if (_item isEqualTo "") exitWith {-1};
+
+// Check if given item is a vehicle
+private _namespace = if (isClass (configFile >> "CfgVehicles" >> _item)) then {
+    GVAR(policeVehiclesScores)
+} else {
+    GVAR(policeEquipmentScores)
+};
+
+// Lowercase search only
+_item = toLower _item;
+
+// Check all scores in given namespace and find
+private _requiredScore = ({
+    private _itemsList = _namespace getVariable _x;
+    if (_item in _itemsList) exitWith {parseNumber _x};
+} forEach (allVariables _namespace));
+
+// Not found
+if (isNil "_requiredScore") exitWith {-1};
+
+// Return search result
+_requiredScore

--- a/addons/equipment/functions/fnc_initEquipment.sqf
+++ b/addons/equipment/functions/fnc_initEquipment.sqf
@@ -46,4 +46,5 @@ GVAR(equipmentPreset) = _equipmentPresetConfig;
 
 [GVAR(equipmentPreset)] call FUNC(initCommonEquipment);
 [GVAR(equipmentPreset)] call FUNC(initPoliceEquipment);
+[GVAR(equipmentPreset)] call FUNC(initPoliceVehicles);
 [GVAR(equipmentPreset)] call FUNC(initKillersEquipment);

--- a/addons/equipment/functions/fnc_initPoliceVehicles.sqf
+++ b/addons/equipment/functions/fnc_initPoliceVehicles.sqf
@@ -1,0 +1,42 @@
+#include "script_component.hpp"
+/*
+ * Author: 3Mydlo3
+ * Function prepares police vehicles from given config.
+ *
+ * Arguments:
+ * 0: Eqipment config <CONFIG>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * None
+ *
+ * Public: No
+ */
+
+params ["_equipmentPresetConfig"];
+
+// Get all defined vehicles and sort by required score from lowest to highest
+private _policeVehicles = [(_equipmentPresetConfig >> "Police" >> "Vehicles")] call FUNC(readConfigToNamespace);
+private _policeVehiclesList = [];
+{
+    private _vehicleClassname = _x;
+    private _vehicle = _policeVehicles getVariable _vehicleClassname;
+    private _vehicleRequiredScore = _vehicle getVariable ["requiredScore", 0];
+    _policeVehiclesList pushBack [_vehicleRequiredScore, _x];
+} forEach (allVariables _policeVehicles);
+_policeVehiclesList sort true;
+
+// Fill GVAR(policeVehiclesScores) namespace
+{
+    private _vehicleRequiredScore = _x select 0;
+    private _vehicleClassName = _x select 1;
+    private _requiredScoreList = GVAR(policeVehiclesScores) getVariable [str _vehicleRequiredScore, []];
+    if (_requiredScoreList isEqualTo []) then {
+        GVAR(policeVehiclesScores) setVariable [str _vehicleRequiredScore, _requiredScoreList];
+    };
+    if (!((GVAR(policeVehiclesList) pushBackUnique _vehicleClassName) isEqualTo -1)) then {
+        _requiredScoreList pushBack _vehicleClassName;
+    };
+} forEach _policeVehiclesList;

--- a/addons/police/XEH_PREP.hpp
+++ b/addons/police/XEH_PREP.hpp
@@ -1,3 +1,4 @@
+PREP(addVehiclesToSpawner);
 PREP(copKilled);
 PREP(copKilledMarker);
 PREP(copKilledMsg);
@@ -6,4 +7,5 @@ PREP(equipmentScoreCheck);
 PREP(initPoliceStation);
 PREP(policeStationAlarm);
 PREP(policeStationMarker);
+PREP(removeVehiclesFromSpawner);
 PREP(teleport);

--- a/addons/police/XEH_PREP.hpp
+++ b/addons/police/XEH_PREP.hpp
@@ -5,6 +5,7 @@ PREP(copKilledMsg);
 PREP(createTeleport);
 PREP(equipmentScoreCheck);
 PREP(initPoliceStation);
+PREP(initSpawner);
 PREP(policeStationAlarm);
 PREP(policeStationMarker);
 PREP(removeVehiclesFromSpawner);

--- a/addons/police/XEH_PREP.hpp
+++ b/addons/police/XEH_PREP.hpp
@@ -8,4 +8,5 @@ PREP(initPoliceStation);
 PREP(policeStationAlarm);
 PREP(policeStationMarker);
 PREP(removeVehiclesFromSpawner);
+PREP(spawnVehicle);
 PREP(teleport);

--- a/addons/police/XEH_postInit.sqf
+++ b/addons/police/XEH_postInit.sqf
@@ -25,6 +25,11 @@ if (isServer) then {
     [QGVAR(policeStationAlarm), {
         _this call FUNC(policeStationAlarm);
     }] call CBA_fnc_addEventHandler;
+
+    // Event creating new police vehicle
+    [QGVAR(spawnVehicle), {
+        _this call FUNC(spawnVehicle);
+    }] call CBA_fnc_addEventHandler;
 };
 
 // Fill arsenal with starting items

--- a/addons/police/functions/fnc_addVehiclesToSpawner.sqf
+++ b/addons/police/functions/fnc_addVehiclesToSpawner.sqf
@@ -22,12 +22,21 @@ if (_vehicles isEqualType "") then {
     _vehicles = [_vehicles];
 };
 
+// Variable contains namespace (classname -> actionID) for easy action removal
 private _vehicleActions = _spawner getVariable QGVAR(vehicleActions);
+
+// Add actions for all vehicles
 {
+    // Check if action for given classname is already added
     private _actionID = _vehicleActions getVariable [_x, -1];
     if (_actionID isEqualTo -1) then {
+        // Create action
         private _vehicleName = getText (configFile >> "CfgVehicles" >> _x >> "displayName");
-        private _actionID = _spawner addAction [_vehicleName, {[QGVAR(spawnVehicle), _this select 3] call CBA_fnc_serverEvent}, [_x, _spawner]];
+        private _vehicleRequiredScore = [_x] call EFUNC(equipment,getRequiredScoreForItem);
+        private _actionText = format ["(%1) %2", _vehicleRequiredScore, _vehicleName];
+        private _actionID = _spawner addAction [_actionText, {[QGVAR(spawnVehicle), _this select 3] call CBA_fnc_serverEvent}, [_x, _spawner], _vehicleRequiredScore, true, true, "", "true", 3];
+
+        // Assign to namespace
         _vehicleActions setVariable [_x, _actionID];
     };
 } forEach _vehicles;

--- a/addons/police/functions/fnc_addVehiclesToSpawner.sqf
+++ b/addons/police/functions/fnc_addVehiclesToSpawner.sqf
@@ -1,0 +1,33 @@
+#include "script_component.hpp"
+/*
+ * Author: 3Mydlo3
+ * Function adds vehicles to spawner
+ *
+ * Arguments:
+ * 0: Spawner object <OBJECT>
+ * 1: Vehicles to add <ARRAY>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [bob, ["B_GEN_Offroad_01_gen_F"]] call afsk_police_fnc_addVehiclesToSpawner
+ *
+ * Public: No
+ */
+
+params ["_spawner", "_vehicles"];
+
+if (_vehicles isEqualType "") then {
+    _vehicles = [_vehicles];
+};
+
+private _vehicleActions = _spawner getVariable QGVAR(vehicleActions);
+{
+    private _actionID = _vehicleActions getVariable [_x, -1];
+    if (_actionID isEqualTo -1) then {
+        private _vehicleName = getText (configFile >> "CfgVehicles" >> _x >> "displayName");
+        private _actionID = _spawner addAction [_vehicleName, {[QGVAR(spawnVehicle), _this select 3] call CBA_fnc_serverEvent}, [_x, _spawner]];
+        _vehicleActions setVariable [_x, _actionID];
+    };
+} forEach _vehicles;

--- a/addons/police/functions/fnc_equipmentScoreCheck.sqf
+++ b/addons/police/functions/fnc_equipmentScoreCheck.sqf
@@ -23,12 +23,15 @@ while {GVAR(lastEquipmentUpdateScore) != EGVAR(score,policeScore)} do {
     };
     diag_log format ["[AFSK] [POLICE] [equipmentScoreCheck] Checking %1", GVAR(lastEquipmentUpdateScore)];
     private _scoreItems = EGVAR(equipment,policeEquipmentScores) getVariable [str GVAR(lastEquipmentUpdateScore), []];
-    diag_log format ["[AFSK] [POLICE] [equipmentScoreCheck] Found %1", _scoreItems];
+    private _scoreVehicles = EGVAR(equipment,policeVehiclesScores) getVariable [str GVAR(lastEquipmentUpdateScore), []];
+    diag_log format ["[AFSK] [POLICE] [equipmentScoreCheck] Found %1 equipment and %2 vehicles", _scoreItems, _scoreVehicles];
     {
         if (_step > 0) then {
             [_x, _scoreItems] call EFUNC(common,addItemsToArsenal);
+            [_x, _scoreVehicles] call FUNC(addVehiclesToSpawner);
         } else {
             [_x, _scoreItems] call EFUNC(common,removeItemsFromArsenal);
+            [_x, _scoreVehicles] call FUNC(removeVehiclesFromSpawner);
         };
     } forEach GVAR(arsenals);
     if (_step < 0) then {

--- a/addons/police/functions/fnc_initPoliceStation.sqf
+++ b/addons/police/functions/fnc_initPoliceStation.sqf
@@ -24,7 +24,6 @@ private _hasHelipad = _logic getVariable ["HasHelipad", false];
 private _basePos = getPos _logic;
 private _flag = createVehicle ["Flag_US_F", _basePos, [], 0, "NONE"];
 _flag setVariable ["policeStation", _logic, true];
-// Init vehicle spawners here
 // Init arsenal
 private _box = createVehicle ["B_CargoNet_01_ammo_F", _basePos, [], 0, "NONE"];
 clearItemCargoGlobal _box;
@@ -35,7 +34,9 @@ _box setVariable ["policeStation", _logic, true];
 [_box] call EFUNC(common,createArsenal);
 GVAR(arsenals) pushBack _box;
 publicVariable QGVAR(arsenals);
-
+// Init vehicle spawner
+// Variable contains vehicle classname -> action id connection
+_box setVariable [QGVAR(vehicleActions), true call CBA_fnc_createNamespace];
 // Create marker
 private _marker = [_baseName, _basePos] call FUNC(policeStationMarker);
 _logic setVariable ["Marker", _marker];

--- a/addons/police/functions/fnc_initPoliceStation.sqf
+++ b/addons/police/functions/fnc_initPoliceStation.sqf
@@ -24,6 +24,7 @@ private _hasHelipad = _logic getVariable ["HasHelipad", false];
 private _basePos = getPos _logic;
 private _flag = createVehicle ["Flag_US_F", _basePos, [], 0, "NONE"];
 _flag setVariable ["policeStation", _logic, true];
+
 // Init arsenal
 private _box = createVehicle ["B_CargoNet_01_ammo_F", _basePos, [], 0, "NONE"];
 clearItemCargoGlobal _box;
@@ -34,9 +35,10 @@ _box setVariable ["policeStation", _logic, true];
 [_box] call EFUNC(common,createArsenal);
 GVAR(arsenals) pushBack _box;
 publicVariable QGVAR(arsenals);
+
 // Init vehicle spawner
-// Variable contains vehicle classname -> action id connection
-_box setVariable [QGVAR(vehicleActions), true call CBA_fnc_createNamespace];
+[_box] call FUNC(initSpawner);
+
 // Create marker
 private _marker = [_baseName, _basePos] call FUNC(policeStationMarker);
 _logic setVariable ["Marker", _marker];

--- a/addons/police/functions/fnc_initSpawner.sqf
+++ b/addons/police/functions/fnc_initSpawner.sqf
@@ -1,0 +1,32 @@
+#include "script_component.hpp"
+/*
+ * Author: 3Mydlo3
+ * Function assigns spawn points in base area to given spawner
+ *
+ * Arguments:
+ * 0: Spawner <OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [bob] call afsk_police_fnc_initSpawner
+ *
+ * Public: No
+ */
+
+params ["_spawner"];
+
+private _policeBase = _spawner getVariable "policeStation";
+private _baseArea = [getPos _policeBase] + (_policeBase getVariable "objectArea");
+
+// Variable contains vehicle classname -> action id connection
+_spawner setVariable [QGVAR(vehicleActions), true call CBA_fnc_createNamespace];
+
+// Find all spawn points within police base
+private _spawnPoints = (allMissionObjects "VR_Area_01_circle_4_grey_F") inAreaArray _baseArea;
+private _helipads = (allMissionObjects "Helipad_base_F") inAreaArray _baseArea;
+
+// Assign found spawn points for easier access
+_spawner setVariable [QGVAR(spawnPoints), _spawnPoints, true];
+_spawner setVariable [QGVAR(helipads), _helipads, true];

--- a/addons/police/functions/fnc_initSpawner.sqf
+++ b/addons/police/functions/fnc_initSpawner.sqf
@@ -21,7 +21,7 @@ private _policeBase = _spawner getVariable "policeStation";
 private _baseArea = [getPos _policeBase] + (_policeBase getVariable "objectArea");
 
 // Variable contains vehicle classname -> action id connection
-_spawner setVariable [QGVAR(vehicleActions), true call CBA_fnc_createNamespace];
+_spawner setVariable [QGVAR(vehicleActions), true call CBA_fnc_createNamespace, true];
 
 // Find all spawn points within police base
 private _spawnPoints = (allMissionObjects "VR_Area_01_circle_4_grey_F") inAreaArray _baseArea;

--- a/addons/police/functions/fnc_removeVehiclesFromSpawner.sqf
+++ b/addons/police/functions/fnc_removeVehiclesFromSpawner.sqf
@@ -1,0 +1,32 @@
+#include "script_component.hpp"
+/*
+ * Author: 3Mydlo3
+ * Function removes vehicles from spawner
+ *
+ * Arguments:
+ * 0: Spawner object <OBJECT>
+ * 1: Vehicles to remove <ARRAY>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [bob, ["B_GEN_Offroad_01_gen_F"]] call afsk_police_fnc_removeVehiclesFromSpawner
+ *
+ * Public: No
+ */
+
+params ["_spawner", "_vehicles"];
+
+if (_vehicles isEqualType "") then {
+    _vehicles = [_vehicles];
+};
+
+private _vehicleActions = _spawner getVariable QGVAR(vehicleActions);
+{
+    private _actionID = _vehicleActions getVariable [_x, -1];
+    if (!(_actionID isEqualTo -1)) then {
+        _spawner removeAction _actionID;
+        _vehicleActions setVariable [_x, nil];
+    };
+} forEach _vehicles;

--- a/addons/police/functions/fnc_spawnVehicle.sqf
+++ b/addons/police/functions/fnc_spawnVehicle.sqf
@@ -1,0 +1,21 @@
+#include "script_component.hpp"
+/*
+ * Author: 3Mydlo3
+ * Function spawns new police vehicle at given spawner
+ *
+ * Arguments:
+ * 0: Vehicle classname <STRING>
+ * 1: Spawner <OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * ["B_GEN_Offroad_01_gen_F", bob] call afsk_police_fnc_spawnVehicle
+ *
+ * Public: No
+ */
+
+params ["_vehicleClassname", "_spawner"];
+
+[_vehicleClassname, _spawner, getDir _spawner, true, false] call EFUNC(civilian,createVehicle);

--- a/addons/police/functions/fnc_spawnVehicle.sqf
+++ b/addons/police/functions/fnc_spawnVehicle.sqf
@@ -32,8 +32,9 @@ private _position = [];
 private _direction = 0;
 while {_position isEqualTo [] && {!(_spawnPoints isEqualTo [])}} do {
     private _spawnPoint = [_spawnPoints] call EFUNC(common,deleteAtRandom);
-    _position = getPos (_spawnPoint) findEmptyPosition [0, 0, _vehicleClassname];
-    if (!(_position isEqualTo [])) exitWith {
+    private _objects = (getPos _spawnPoint) nearEntities 5;
+    if (_objects isEqualTo []) exitWith {
+        _position = getPos _spawnPoint;
         _direction = getDir _spawnPoint;
     };
 };

--- a/addons/police/functions/fnc_spawnVehicle.sqf
+++ b/addons/police/functions/fnc_spawnVehicle.sqf
@@ -27,6 +27,7 @@ private _spawnPoints = if (_vehicleType isEqualTo "Helicopter" || {_vehicleType 
     +(_spawner getVariable QGVAR(spawnPoints))
 };
 
+// Find empty spawn position
 private _position = [];
 private _direction = 0;
 while {_position isEqualTo [] && {!(_spawnPoints isEqualTo [])}} do {
@@ -37,6 +38,7 @@ while {_position isEqualTo [] && {!(_spawnPoints isEqualTo [])}} do {
     };
 };
 
+// Show message if no empty spawn position
 if (_position isEqualTo []) exitWith {
     private _baseName = (_spawner getVariable "policeStation") getVariable "LocationName";
     private _vehicleName = getText (configFile >> "CfgVehicles" >> _vehicleClassname >> "displayName");
@@ -44,4 +46,5 @@ if (_position isEqualTo []) exitWith {
     [QEGVAR(common,showSideChatMsg), [WEST, _msg]] call CBA_fnc_globalEvent;
 };
 
+// Spawn vehicle
 [_vehicleClassname, _position, _direction, true, false] call EFUNC(civilian,createVehicle);

--- a/addons/police/functions/fnc_spawnVehicle.sqf
+++ b/addons/police/functions/fnc_spawnVehicle.sqf
@@ -18,4 +18,30 @@
 
 params ["_vehicleClassname", "_spawner"];
 
-[_vehicleClassname, _spawner, getDir _spawner, true, false] call EFUNC(civilian,createVehicle);
+private _vehicleType = (_vehicleClassname call BIS_fnc_objectType) select 1;
+
+// Select approriate spawn point for given vehicle
+private _spawnPoints = if (_vehicleType isEqualTo "Helicopter" || {_vehicleType isEqualTo "Plane"}) then {
+    +(_spawner getVariable QGVAR(helipads))
+} else {
+    +(_spawner getVariable QGVAR(spawnPoints))
+};
+
+private _position = [];
+private _direction = 0;
+while {_position isEqualTo [] && {!(_spawnPoints isEqualTo [])}} do {
+    private _spawnPoint = [_spawnPoints] call EFUNC(common,deleteAtRandom);
+    _position = getPos (_spawnPoint) findEmptyPosition [0, 0, _vehicleClassname];
+    if (!(_position isEqualTo [])) exitWith {
+        _direction = getDir _spawnPoint;
+    };
+};
+
+if (_position isEqualTo []) exitWith {
+    private _baseName = (_spawner getVariable "policeStation") getVariable "LocationName";
+    private _vehicleName = getText (configFile >> "CfgVehicles" >> _vehicleClassname >> "displayName");
+    private _msg = format ["Cannot create %1 at %2.", _vehicleName, _baseName];
+    [QEGVAR(common,showSideChatMsg), [WEST, _msg]] call CBA_fnc_globalEvent;
+};
+
+[_vehicleClassname, _position, _direction, true, false] call EFUNC(civilian,createVehicle);

--- a/addons/police/functions/fnc_spawnVehicle.sqf
+++ b/addons/police/functions/fnc_spawnVehicle.sqf
@@ -48,4 +48,4 @@ if (_position isEqualTo []) exitWith {
 };
 
 // Spawn vehicle
-[_vehicleClassname, _position, _direction, true, false] call EFUNC(civilian,createVehicle);
+[_vehicleClassname, _position, _direction, true, false, true] call EFUNC(civilian,createVehicle);


### PR DESCRIPTION
**When merged this pull request will:**
- Add basic vehicles config (`CfgSerialKIllers >> Equipment_Presets >> Vanilla >> Police >> Vehicles`)
- Use arsenal box as vehicle spawner
- Use helipad objects for helicopters spawn points
- Use 4x4 circular area helper object as vehicle spawn points
- Support multiple spawn points per police base (selects random empty spawn point)
- Automatic adding/removing of available vehicles according to current police score
- `EFUNC(civilian,createVehicle)` add _enableRadomization param
- Disable randomization for police vehicles (to avoid randomized police cars)
