### PR TITLE
Dedicated server score/respawn/msg events fixes

### DIFF
--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -42,7 +42,7 @@ if (hasInterface) then {
         if (_msg isEqualTo "") exitWith {};
         // If side is empty we want to show message to everyone
         if (_side isEqualTo sideEmpty || {playerSide isEqualTo _side}) then {
-            [_side, "HQ"] sideChat _msg;
+            [playerSide, "HQ"] sideChat _msg;
         };
     }] call CBA_fnc_addEventHandler;
 };

--- a/addons/police/XEH_postInit.sqf
+++ b/addons/police/XEH_postInit.sqf
@@ -51,7 +51,7 @@ if (!isServer) then {
     player addEventHandler ["Killed", {
         [QGVAR(copKilled), _this] call CBA_fnc_serverEvent;
     }];
-    player addEventHandler ["Respawned", {
+    player addEventHandler ["Respawn", {
         [QGVAR(copRespawned), _this] call CBA_fnc_serverEvent;
     }];
 };

--- a/addons/score/XEH_postInit.sqf
+++ b/addons/score/XEH_postInit.sqf
@@ -27,12 +27,7 @@ if (isServer) then {
         } else {
             [_change, _reason] call FUNC(addKillersScore);
         };
-        [QGVAR(scoreChanged), _this] call CBA_fnc_serverEvent;
-    }] call CBA_fnc_addEventHandler;
-
-    [QGVAR(scoreChanged), {
-        params ["_side", "_change", ["_reason", ""]];
-        [QGVAR(showScore), [_reason]] call CBA_fnc_globalEvent;
+        [QGVAR(scoreChanged), _this] call CBA_fnc_globalEvent;
     }] call CBA_fnc_addEventHandler;
 
     /* Serverside score logic init */
@@ -52,6 +47,11 @@ if (isServer) then {
         call FUNC(monitorTimeouts);
     }, [], GVAR(idleTimeMax)] call CBA_fnc_waitAndExecute;
 };
+
+[QGVAR(scoreChanged), {
+    params ["_side", "_change", ["_reason", ""]];
+    [QGVAR(showScore), [_reason]] call CBA_fnc_localEvent;
+}] call CBA_fnc_addEventHandler;
 
 
 if (hasInterface) then {

--- a/addons/score/functions/fnc_addKillersScore.sqf
+++ b/addons/score/functions/fnc_addKillersScore.sqf
@@ -33,8 +33,6 @@ publicVariable QGVAR(killersScoreChange);
     };
 }, [GVAR(killersScoreChange)], 5] call CBA_fnc_waitAndExecute;
 
-[_reason] call FUNC(showScore);
-
 // Check if killers have reached their goal
 if (GVAR(killersScore) >= GVAR(killersScoreMax)) then {
     [QGVAR(killersScoreReached), [KILLERS_SCORE_REACHED]] call CBA_fnc_serverEvent;

--- a/addons/score/functions/fnc_addPoliceScore.sqf
+++ b/addons/score/functions/fnc_addPoliceScore.sqf
@@ -32,5 +32,3 @@ publicVariable QGVAR(policeScoreChange);
         publicVariable QGVAR(policeScoreChange);
     };
 }, [GVAR(policeScoreChange)], 5] call CBA_fnc_waitAndExecute;
-
-[_reason] call FUNC(showScore);


### PR DESCRIPTION
**When merged this pull request will:**
- Fix `scoreChanged` event not available on clients
- Fix wrong respawn eventhandler
- Use `playerSide` in `EGVAR(common,showSideChatMsg)` event