### PR TITLE
Make civilians start more compacted in cities/villages

### DIFF
--- a/addons/civilian/functions/fnc_initCivilians.sqf
+++ b/addons/civilian/functions/fnc_initCivilians.sqf
@@ -18,6 +18,7 @@
 #define NEAR_ROAD true
 #define ALLOW_ON_ROAD true
 #define NEAR_BUILDINGS true
+#define MAX_DISTANCE_TO_VILLAGE 500
 #define MAX_DISTANCE_TO_NEAREST_CITY 1000
 
 private _i = GVAR(initialCiviliansCount);
@@ -27,6 +28,12 @@ while {_i > 0} do {
     if (!(_pos isEqualTo [])) then {
         private _nearestCity = [_pos, MAX_DISTANCE_TO_NEAREST_CITY] call FUNC(getNearestCity);
         if (_nearestCity isEqualTo objNull) exitWith {};
+
+        private _nearestCityType = _nearestCity getVariable [QGVAR(cityType), "NameVillage"];
+        private _cityPosition = _nearestCity getVariable [QGVAR(position), [0, 0, 0]];
+        private _maxAllowedDistance = if (_nearestCityType isEqualTo "NameVillage") then { MAX_DISTANCE_TO_VILLAGE } else { MAX_DISTANCE_TO_NEAREST_CITY };
+        if (_pos distance _cityPosition > _maxAllowedDistance) exitWith {};
+
         private _nearbyCivilians = _pos nearEntities ["Man", 100];
         private _nearbyCiviliansCount = count _nearbyCivilians;
         if (_nearbyCiviliansCount >= 2 && {(random 1) - _nearbyCiviliansCount * 0.05 > 0.1}) exitWith {};

--- a/addons/civilian/functions/fnc_initCivilians.sqf
+++ b/addons/civilian/functions/fnc_initCivilians.sqf
@@ -27,6 +27,10 @@ while {_i > 0} do {
     if (!(_pos isEqualTo [])) then {
         private _nearestCity = [_pos, MAX_DISTANCE_TO_NEAREST_CITY] call FUNC(getNearestCity);
         if (_nearestCity isEqualTo objNull) exitWith {};
+        private _nearbyCivilians = _pos nearEntities ["Man", 100];
+        private _nearbyCiviliansCount = count _nearbyCivilians;
+        if (_nearbyCiviliansCount >= 2 && {(random 1) - _nearbyCiviliansCount * 0.05 > 0.1}) exitWith {};
+
         [_pos] call FUNC(createCivilian);
         _i = _i - 1;
     };

--- a/addons/civilian/functions/fnc_initCivilians.sqf
+++ b/addons/civilian/functions/fnc_initCivilians.sqf
@@ -15,12 +15,17 @@
  * Public: No
  */
 
+#define NEAR_ROAD true
+#define ALLOW_ON_ROAD true
+#define NEAR_BUILDINGS true
+#define MAX_DISTANCE_TO_NEAREST_CITY 1000
+
 private _i = GVAR(initialCiviliansCount);
 
 while {_i > 0} do {
-    private _pos = [nil, false, true, true] call EFUNC(common,getRandomPos);
+    private _pos = [nil, NEAR_ROAD, ALLOW_ON_ROAD, NEAR_BUILDINGS] call EFUNC(common,getRandomPos);
     if (!(_pos isEqualTo [])) then {
-        private _nearestCity = [_pos, 1500] call FUNC(getNearestCity);
+        private _nearestCity = [_pos, MAX_DISTANCE_TO_NEAREST_CITY] call FUNC(getNearestCity);
         if (_nearestCity isEqualTo objNull) exitWith {};
         [_pos] call FUNC(createCivilian);
         _i = _i - 1;


### PR DESCRIPTION
**When merged this pull request will:**
- [x] Make civilians start in cities only (near buildings and roads)
- [x] Distinguish between city and village

For the future:
- Consider selection of generation algorithms for different needs
- Consider redesigning algorithm (or add one) to actually select city from the list and only then look for position. This will prevent issues with small villages being empty in many games.