### PR TITLE
Prevent "Undefined variable in expression: _t" by excluding scope < 2 civilian units in automatic config

### DIFF
--- a/addons/civilian/functions/fnc_initConfig.sqf
+++ b/addons/civilian/functions/fnc_initConfig.sqf
@@ -23,7 +23,7 @@ private _civilianUnitsConfigs = if (_customCivilianUnits isNotEqualTo []) then {
     _customCivilianUnits apply {configFile >> "CfgVehicles" >> _x};
 } else {
     // By default load all civilian units
-    QUOTE((configFile >> 'CfgVehicles' >> 'C_man_1') in ([_x] call EFUNC(common,configGetAllParents))) configClasses (configFile >> "CfgVehicles");
+    QUOTE((configFile >> 'CfgVehicles' >> 'C_man_1') in ([_x] call EFUNC(common,configGetAllParents)) && getNumber (_x >> 'scope') > 1) configClasses (configFile >> "CfgVehicles");
 };
 
 // TODO: Add blacklisted units config to exclude VR guys


### PR DESCRIPTION
**When merged this pull request will:**
- title

Fixes #65.