### PR TITLE
Show civilian vehicles markers for killers from the start without requiring teleportation

### DIFF
--- a/addons/killers/functions/fnc_createMarkersForNearbyVehicles.sqf
+++ b/addons/killers/functions/fnc_createMarkersForNearbyVehicles.sqf
@@ -21,7 +21,8 @@ params ["_position", ["_radius", 1000]];
 
 private _nearbyVehicles = _position nearEntities [["Air", "Car", "Motorcycle", "Tank"], _radius];
 private _emptyVehicles = _nearbyVehicles select {
-    crew _x isEqualTo []
+    damage _x isEqualTo 0 &&
+    {crew _x isEqualTo []}
 };
 
 {

--- a/addons/killers/functions/fnc_createMarkersForNearbyVehicles.sqf
+++ b/addons/killers/functions/fnc_createMarkersForNearbyVehicles.sqf
@@ -29,6 +29,7 @@ private _emptyVehicles = _nearbyVehicles select {
     private _vehicle = _x;
     private _marker = createMarkerLocal [format ["vehicle_%1", _vehicle], getPosATL _vehicle];
     _marker setMarkerColorLocal "ColorCIVILIAN";
+    _marker setMarkerSizeLocal [0.5, 0.5];
     _marker setMarkerTextLocal getText (configFile >> "CfgVehicles" >> (typeof _vehicle) >> "displayName");
 
     private _markerType = if (_vehicle isKindOf "Air") then {

--- a/addons/killers/functions/fnc_createMarkersForNearbyVehicles.sqf
+++ b/addons/killers/functions/fnc_createMarkersForNearbyVehicles.sqf
@@ -27,9 +27,12 @@ private _emptyVehicles = _nearbyVehicles select {
 
 {
     private _vehicle = _x;
-    private _marker = createMarkerLocal [format ["vehicle_%1", _vehicle], getPosATL _vehicle];
+    private _markerName = format ["vehicle_%1", _vehicle];
+    private _marker = createMarkerLocal [_markerName, getPosATL _vehicle];
+    if (_marker isEqualTo "") then { _marker = _markerName };
     _marker setMarkerColorLocal "ColorCIVILIAN";
     _marker setMarkerSizeLocal [0.5, 0.5];
+    _marker setMarkerAlphaLocal 1; // Force just in case marker already exists and should be fully-visible again
     _marker setMarkerTextLocal getText (configFile >> "CfgVehicles" >> (typeof _vehicle) >> "displayName");
 
     private _markerType = if (_vehicle isKindOf "Air") then {

--- a/addons/killers/functions/fnc_createMarkersForNearbyVehicles.sqf
+++ b/addons/killers/functions/fnc_createMarkersForNearbyVehicles.sqf
@@ -28,6 +28,9 @@ private _emptyVehicles = _nearbyVehicles select {
 {
     private _vehicle = _x;
     private _markerName = format ["vehicle_%1", _vehicle];
+    private _markerExists = getMarkerPos _markerName isNotEqualTo [0, 0, 0];
+    if (_markerExists) then { continue };
+
     private _marker = createMarkerLocal [_markerName, getPosATL _vehicle];
     if (_marker isEqualTo "") then { _marker = _markerName };
     _marker setMarkerColorLocal "ColorCIVILIAN";

--- a/addons/killers/functions/fnc_createMarkersForNearbyVehicles.sqf
+++ b/addons/killers/functions/fnc_createMarkersForNearbyVehicles.sqf
@@ -35,7 +35,7 @@ private _emptyVehicles = _nearbyVehicles select {
         } else { "loc_car" };
     _marker setMarkerTypeLocal _markerType;
 
-    [_marker, 2, true] call EFUNC(markers,markerDecay);
+    [_marker, 2.5, true] call EFUNC(markers,markerDecay);
 } forEach _emptyVehicles;
 
 nil

--- a/addons/killers/functions/fnc_createTeleport.sqf
+++ b/addons/killers/functions/fnc_createTeleport.sqf
@@ -28,6 +28,7 @@ private _positionID = 0;
         [QGVAR(teleportedToStart), [_this select 0]] call CBA_fnc_localEvent;
     }, [_destinationPos]];
     [_destinationPos, _destinationName] call FUNC(createStartPositionMarker);
+    [_destinationPos] call FUNC(createMarkersForNearbyVehicles);
     // Add for deletion after teleportation
     _teleportActionsIDs pushBack _teleportActionID;
     _positionID = _positionID + 1;

--- a/addons/markers/functions/fnc_markerDecay.sqf
+++ b/addons/markers/functions/fnc_markerDecay.sqf
@@ -20,5 +20,6 @@ params ["_marker", ["_decayHalfTime", 10], ["_local", false]];
 
 // How much decay will be applied every 15 seconds
 private _decayRate = 1/(_decayHalfTime * 4 * 2);
+private _currentAlpha = markerAlpha _marker;
 
-[_marker, _decayRate, _local] call FUNC(markerDecayLoop);
+[_marker, _decayRate, _currentAlpha, _local] call FUNC(markerDecayLoop);

--- a/addons/markers/functions/fnc_markerDecayLoop.sqf
+++ b/addons/markers/functions/fnc_markerDecayLoop.sqf
@@ -16,16 +16,19 @@
  * Public: No
  */
 
-params ["_marker", "_decayRate", ["_local", false]];
+params ["_marker", "_decayRate", ["_previousAlpha", -1], ["_local", false]];
 
 private _currentAlpha = markerAlpha _marker;
 
+if (_currentAlpha isNotEqualTo _previousAlpha && {_previousAlpha isNotEqualTo -1}) exitWith {};
 if (_currentAlpha <= _decayRate) exitWith {deleteMarker _marker};
 
+private _newAlpha = (_currentAlpha - _decayRate);
+
 if (_local) then {
-    _marker setMarkerAlphaLocal (_currentAlpha - _decayRate);
+    _marker setMarkerAlphaLocal _newAlpha;
 } else {
-    _marker setMarkerAlpha (_currentAlpha - _decayRate);
+    _marker setMarkerAlpha _newAlpha;
 };
 
-[FUNC(markerDecayLoop), [_marker, _decayRate, _local], 15] call CBA_fnc_waitAndExecute;
+[FUNC(markerDecayLoop), [_marker, _decayRate, _newAlpha, _local], 15] call CBA_fnc_waitAndExecute;


### PR DESCRIPTION
**When merged this pull request will:**
- title
- Prevent markers on damaged/destroyed vehicles
- Make markers smaller as it's quite a lot of them and clutter the map